### PR TITLE
Revert "Fix "Configuration files for `cljfmt` are ignored""

### DIFF
--- a/src/clojure_mcp/tools/file_edit/pipeline.clj
+++ b/src/clojure_mcp/tools/file_edit/pipeline.clj
@@ -62,14 +62,10 @@
    - Updated context with formatted content for Clojure files, or unchanged for other file types"
   [ctx]
   (let [file-path (::form-pipeline/file-path ctx)
-        output-source (::form-pipeline/output-source ctx)
-        nrepl-client-map @(::nrepl-client-atom ctx)
-        formatting-options (form-edit-core/project-formatting-options nrepl-client-map)]
+        output-source (::form-pipeline/output-source ctx)]
     (if (and (file-write-core/is-clojure-file? file-path) output-source)
       (try
-        (let [formatted-source (form-edit-core/format-source-string
-                                output-source
-                                formatting-options)]
+        (let [formatted-source (form-edit-core/format-source-string output-source)]
           (assoc ctx ::form-pipeline/output-source formatted-source))
         (catch Exception e
           ctx))

--- a/src/clojure_mcp/tools/form_edit/core.clj
+++ b/src/clojure_mcp/tools/form_edit/core.clj
@@ -8,8 +8,6 @@
    [rewrite-clj.node :as n]
    [rewrite-clj.paredit :as par]
    [cljfmt.core :as fmt]
-   [cljfmt.config :as cljfmt-config]
-   [clojure-mcp.config :as config]
    [clojure.string :as str]
    [clojure.java.io :as io]))
 
@@ -619,40 +617,26 @@
 
 ;; Source code formatting
 
-(def default-formatting-options
-  {:indentation? true
-   :remove-surrounding-whitespace? true
-   :remove-trailing-whitespace? true
-   :insert-missing-whitespace? true
-   :remove-consecutive-blank-lines? true
-   :remove-multiple-non-indenting-spaces? true
-   :split-keypairs-over-multiple-lines? false
-   :sort-ns-references? false
-   :function-arguments-indentation :community
-   :indents fmt/default-indents})
-
-(defn- load-cljfmt-config [nrepl-user-dir]
-  (let [path (cljfmt-config/find-config-file nrepl-user-dir)]
-    (->> (some-> path cljfmt-config/read-config)
-         (merge default-formatting-options)
-         (cljfmt-config/convert-legacy-keys))))
-
-(defn project-formatting-options [nrepl-client-map]
-  (let [nrepl-user-dir (config/get-nrepl-user-dir nrepl-client-map)]
-    (load-cljfmt-config nrepl-user-dir)))
-
 (defn format-source-string
-  "Formats a source code string using cljfmt. Use the project-formatting-options
-  function to get comprehensive formatting options for the current project.
+  "Formats a source code string using cljfmt with comprehensive formatting options.
    
    Arguments:
    - source-str: The source code string to format
-   - formatting-options: Options for cljfmt
    
    Returns:
    - The formatted source code string"
-  [source-str formatting-options]
-  (fmt/reformat-string source-str formatting-options))
+  [source-str]
+  (let [formatting-options {:indentation? true
+                            :remove-surrounding-whitespace? true
+                            :remove-trailing-whitespace? true
+                            :insert-missing-whitespace? true
+                            :remove-consecutive-blank-lines? true
+                            :remove-multiple-non-indenting-spaces? true
+                            :split-keypairs-over-multiple-lines? false
+                            :sort-ns-references? false
+                            :function-arguments-indentation :community
+                            :indents fmt/default-indents}]
+    (fmt/reformat-string source-str formatting-options)))
 
 ;; File operations
 

--- a/src/clojure_mcp/tools/form_edit/pipeline.clj
+++ b/src/clojure_mcp/tools/form_edit/pipeline.clj
@@ -414,9 +414,7 @@
   [ctx]
   (try
     (let [source (::output-source ctx)
-          nrepl-client-map @(::nrepl-client-atom ctx)
-          formatting-options (core/project-formatting-options nrepl-client-map)
-          formatted (core/format-source-string source formatting-options)]
+          formatted (core/format-source-string source)]
       (assoc ctx ::output-source formatted))
     (catch Exception e
       ;; Instead of failing, use the original source if available

--- a/test/clojure_mcp/tools/form_edit/core_test.clj
+++ b/test/clojure_mcp/tools/form_edit/core_test.clj
@@ -305,9 +305,7 @@
 (deftest format-source-string-test
   (testing "format-source-string correctly formats source code"
     (let [unformatted "(defn   example-fn[x y]  (+ x  y)   )"
-          formatted (sut/format-source-string
-                     unformatted
-                     sut/default-formatting-options)]
+          formatted (sut/format-source-string unformatted)]
       ;; Compare as EDN to ignore whitespace differences
       (is (= (read-string unformatted) (read-string formatted))))))
 


### PR DESCRIPTION
Reverts bhauman/clojure-mcp#21 

Tests are failing from this commit.