### PR TITLE
Fix "Configuration files for `cljfmt` are ignored" (tests passing)

### DIFF
--- a/src/clojure_mcp/tools/file_edit/pipeline.clj
+++ b/src/clojure_mcp/tools/file_edit/pipeline.clj
@@ -62,10 +62,14 @@
    - Updated context with formatted content for Clojure files, or unchanged for other file types"
   [ctx]
   (let [file-path (::form-pipeline/file-path ctx)
-        output-source (::form-pipeline/output-source ctx)]
+        output-source (::form-pipeline/output-source ctx)
+        nrepl-client-map @(::form-pipeline/nrepl-client-atom ctx)
+        formatting-options (form-edit-core/project-formatting-options nrepl-client-map)]
     (if (and (file-write-core/is-clojure-file? file-path) output-source)
       (try
-        (let [formatted-source (form-edit-core/format-source-string output-source)]
+        (let [formatted-source (form-edit-core/format-source-string
+                                output-source
+                                formatting-options)]
           (assoc ctx ::form-pipeline/output-source formatted-source))
         (catch Exception e
           ctx))

--- a/src/clojure_mcp/tools/file_write/core.clj
+++ b/src/clojure_mcp/tools/file_write/core.clj
@@ -29,13 +29,14 @@
    
    Returns:
    - A map with :error, :type, :file-path, and :diff keys"
-  [file-path content]
+  [nrepl-client-atom file-path content]
   (let [file (io/file file-path)
         file-exists? (.exists file)
         old-content (if file-exists? (slurp file) "")
 
         ;; Create a context map for the pipeline
-        initial-ctx {::pipeline/file-path file-path
+        initial-ctx {::pipeline/nrepl-client-atom nrepl-client-atom
+                     ::pipeline/file-path file-path
                      ::pipeline/source old-content
                      ::pipeline/new-source-code content
                      ::pipeline/old-content old-content
@@ -104,7 +105,7 @@
    
    Returns:
    - A map with :error, :type, :file-path, and :diff keys"
-  [file-path content]
+  [nrepl-client-atom file-path content]
   (if (is-clojure-file? file-path)
-    (write-clojure-file file-path content)
+    (write-clojure-file nrepl-client-atom file-path content)
     (write-text-file file-path content)))

--- a/src/clojure_mcp/tools/file_write/tool.clj
+++ b/src/clojure_mcp/tools/file_write/tool.clj
@@ -87,7 +87,7 @@ Before using this tool:
 
 (defmethod tool-system/execute-tool :file-write [{:keys [nrepl-client-atom]} inputs]
   (let [{:keys [file-path content]} inputs
-        result (core/write-file file-path content)]
+        result (core/write-file nrepl-client-atom file-path content)]
     ;; Update the timestamp if write was successful and we have a client atom
     (when (and nrepl-client-atom (not (:error result)))
       (file-timestamps/update-file-timestamp-to-current-mtime! nrepl-client-atom file-path))

--- a/src/clojure_mcp/tools/form_edit/core.clj
+++ b/src/clojure_mcp/tools/form_edit/core.clj
@@ -8,6 +8,8 @@
    [rewrite-clj.node :as n]
    [rewrite-clj.paredit :as par]
    [cljfmt.core :as fmt]
+   [cljfmt.config :as cljfmt-config]
+   [clojure-mcp.config :as config]
    [clojure.string :as str]
    [clojure.java.io :as io]))
 
@@ -617,26 +619,40 @@
 
 ;; Source code formatting
 
+(def default-formatting-options
+  {:indentation? true
+   :remove-surrounding-whitespace? true
+   :remove-trailing-whitespace? true
+   :insert-missing-whitespace? true
+   :remove-consecutive-blank-lines? true
+   :remove-multiple-non-indenting-spaces? true
+   :split-keypairs-over-multiple-lines? false
+   :sort-ns-references? false
+   :function-arguments-indentation :community
+   :indents fmt/default-indents})
+
+(defn- load-cljfmt-config [nrepl-user-dir]
+  (let [path (cljfmt-config/find-config-file nrepl-user-dir)]
+    (->> (some-> path cljfmt-config/read-config)
+         (merge default-formatting-options)
+         (cljfmt-config/convert-legacy-keys))))
+
+(defn project-formatting-options [nrepl-client-map]
+  (let [nrepl-user-dir (config/get-nrepl-user-dir nrepl-client-map)]
+    (load-cljfmt-config nrepl-user-dir)))
+
 (defn format-source-string
-  "Formats a source code string using cljfmt with comprehensive formatting options.
+  "Formats a source code string using cljfmt. Use the project-formatting-options
+   function to get comprehensive formatting options for the current project.
    
    Arguments:
    - source-str: The source code string to format
+   - formatting-options: Options for cljfmt
    
    Returns:
    - The formatted source code string"
-  [source-str]
-  (let [formatting-options {:indentation? true
-                            :remove-surrounding-whitespace? true
-                            :remove-trailing-whitespace? true
-                            :insert-missing-whitespace? true
-                            :remove-consecutive-blank-lines? true
-                            :remove-multiple-non-indenting-spaces? true
-                            :split-keypairs-over-multiple-lines? false
-                            :sort-ns-references? false
-                            :function-arguments-indentation :community
-                            :indents fmt/default-indents}]
-    (fmt/reformat-string source-str formatting-options)))
+  [source-str formatting-options]
+  (fmt/reformat-string source-str formatting-options))
 
 ;; File operations
 

--- a/src/clojure_mcp/tools/form_edit/pipeline.clj
+++ b/src/clojure_mcp/tools/form_edit/pipeline.clj
@@ -414,7 +414,9 @@
   [ctx]
   (try
     (let [source (::output-source ctx)
-          formatted (core/format-source-string source)]
+          nrepl-client-map @(::nrepl-client-atom ctx)
+          formatting-options (core/project-formatting-options nrepl-client-map)
+          formatted (core/format-source-string source formatting-options)]
       (assoc ctx ::output-source formatted))
     (catch Exception e
       ;; Instead of failing, use the original source if available

--- a/test/clojure_mcp/tools/file_write/core_test.clj
+++ b/test/clojure_mcp/tools/file_write/core_test.clj
@@ -1,6 +1,7 @@
 (ns clojure-mcp.tools.file-write.core-test
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
+   [clojure-mcp.config :as config]
    [clojure-mcp.tools.file-write.core :as file-write-core]
    [clojure-mcp.tools.test-utils :as test-utils]
    [clojure.java.io :as io]
@@ -29,6 +30,7 @@
     (binding [*test-dir* test-dir
               *test-clj-file* test-clj-file
               *test-txt-file* test-txt-file]
+      (config/set-config! test-utils/*nrepl-client-atom* :nrepl-user-dir test-dir)
       (try
         (f)
         (finally
@@ -38,8 +40,8 @@
               (.delete file)))
           (.delete test-dir))))))
 
-(use-fixtures :each create-test-files-fixture)
 (use-fixtures :once test-utils/test-nrepl-fixture)
+(use-fixtures :each create-test-files-fixture)
 
 (deftest is-clojure-file-test
   (testing "Detecting Clojure file extensions"

--- a/test/clojure_mcp/tools/file_write/core_test.clj
+++ b/test/clojure_mcp/tools/file_write/core_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
    [clojure-mcp.tools.file-write.core :as file-write-core]
+   [clojure-mcp.tools.test-utils :as test-utils]
    [clojure.java.io :as io]
    [clojure.string :as str]))
 
@@ -38,6 +39,7 @@
           (.delete test-dir))))))
 
 (use-fixtures :each create-test-files-fixture)
+(use-fixtures :once test-utils/test-nrepl-fixture)
 
 (deftest is-clojure-file-test
   (testing "Detecting Clojure file extensions"
@@ -79,7 +81,10 @@
   (testing "Creating a new Clojure file"
     (let [new-file (io/file *test-dir* "new-file.clj")
           content "(ns new.namespace)\n\n(defn new-function [x]\n  (+ x 10))"
-          result (file-write-core/write-clojure-file (.getPath new-file) content)]
+          result (file-write-core/write-clojure-file
+                   test-utils/*nrepl-client-atom*
+                   (.getPath new-file)
+                   content)]
       (is (not (:error result)))
       (is (= "create" (:type result)))
       (is (= (.getPath new-file) (:file-path result)))
@@ -90,7 +95,10 @@
     (let [path (.getPath *test-clj-file*)
           original-content (slurp *test-clj-file*)
           new-content "(ns test.namespace)\n\n(defn test-function [x]\n  (+ x 10))"
-          result (file-write-core/write-clojure-file path new-content)]
+          result (file-write-core/write-clojure-file
+                   test-utils/*nrepl-client-atom*
+                   path
+                   new-content)]
       (is (not (:error result)))
       (is (= "update" (:type result)))
       (is (= path (:file-path result)))
@@ -100,7 +108,10 @@
   (testing "Formatting Clojure code during write"
     (let [path (.getPath *test-clj-file*)
           unformatted-content "(ns test.namespace)( defn poorly-formatted-fn[x]( + x 5) )"
-          result (file-write-core/write-clojure-file path unformatted-content)]
+          result (file-write-core/write-clojure-file
+                   test-utils/*nrepl-client-atom*
+                   path
+                   unformatted-content)]
       (is (not (:error result)))
       (is (= "update" (:type result)))
       (is (not (str/includes? (slurp *test-clj-file*) "poorly-formatted-fn[x]")))
@@ -109,7 +120,10 @@
   (testing "Auto-repairs missing closing parenthesis"
     (let [path (.getPath *test-clj-file*)
           content-with-missing-paren "(ns test.namespace)\n\n(defn repaired-function [x]\n  (+ x 10)"
-          result (file-write-core/write-clojure-file path content-with-missing-paren)]
+          result (file-write-core/write-clojure-file
+                   test-utils/*nrepl-client-atom*
+                   path
+                   content-with-missing-paren)]
       (is (not (:error result)))
       (is (= "update" (:type result)))
       (let [saved-content (slurp *test-clj-file*)]
@@ -120,7 +134,10 @@
   (testing "Auto-repairs unbalanced brackets"
     (let [path (.getPath *test-clj-file*)
           content-with-mismatched-brackets "(ns test.namespace)\n\n(defn bracket-fn [x]\n  (let [y (+ x 1)]\n    (println y]))"
-          result (file-write-core/write-clojure-file path content-with-mismatched-brackets)]
+          result (file-write-core/write-clojure-file
+                   test-utils/*nrepl-client-atom*
+                   path
+                   content-with-mismatched-brackets)]
       (is (not (:error result)))
       (is (= "update" (:type result)))
       (let [saved-content (slurp *test-clj-file*)]
@@ -132,7 +149,10 @@
     (let [path (.getPath *test-clj-file*)
           content-with-syntax-error "(ns test.namespace)\n\n(defn broken-function a123 [x 11)\n  (+ x 10))"
           original-content (slurp *test-clj-file*)
-          result (file-write-core/write-clojure-file path content-with-syntax-error)]
+          result (file-write-core/write-clojure-file
+                   test-utils/*nrepl-client-atom*
+                   path
+                   content-with-syntax-error)]
       ;; The test should fail with a specific error
       (is (:error result) "Should have error for non-repairable syntax error")
       (when (:message result)
@@ -145,7 +165,9 @@
   (testing "Write dispatcher for Clojure files"
     (let [clj-file (io/file *test-dir* "dispatch-test.clj")
           content "(ns dispatch.test)"
-          result (file-write-core/write-file (.getPath clj-file) content)]
+          result (file-write-core/write-file test-utils/*nrepl-client-atom*
+                                             (.getPath clj-file)
+                                             content)]
       (is (not (:error result)))
       (is (= "create" (:type result)))
       (is (.exists clj-file))
@@ -154,7 +176,9 @@
   (testing "Write dispatcher for text files"
     (let [txt-file (io/file *test-dir* "dispatch-test.txt")
           content "Plain text content"
-          result (file-write-core/write-file (.getPath txt-file) content)]
+          result (file-write-core/write-file test-utils/*nrepl-client-atom*
+                                             (.getPath txt-file)
+                                             content)]
       (is (not (:error result)))
       (is (= "create" (:type result)))
       (is (.exists txt-file))

--- a/test/clojure_mcp/tools/file_write/core_test.clj
+++ b/test/clojure_mcp/tools/file_write/core_test.clj
@@ -84,9 +84,9 @@
     (let [new-file (io/file *test-dir* "new-file.clj")
           content "(ns new.namespace)\n\n(defn new-function [x]\n  (+ x 10))"
           result (file-write-core/write-clojure-file
-                   test-utils/*nrepl-client-atom*
-                   (.getPath new-file)
-                   content)]
+                  test-utils/*nrepl-client-atom*
+                  (.getPath new-file)
+                  content)]
       (is (not (:error result)))
       (is (= "create" (:type result)))
       (is (= (.getPath new-file) (:file-path result)))
@@ -98,9 +98,9 @@
           original-content (slurp *test-clj-file*)
           new-content "(ns test.namespace)\n\n(defn test-function [x]\n  (+ x 10))"
           result (file-write-core/write-clojure-file
-                   test-utils/*nrepl-client-atom*
-                   path
-                   new-content)]
+                  test-utils/*nrepl-client-atom*
+                  path
+                  new-content)]
       (is (not (:error result)))
       (is (= "update" (:type result)))
       (is (= path (:file-path result)))
@@ -111,9 +111,9 @@
     (let [path (.getPath *test-clj-file*)
           unformatted-content "(ns test.namespace)( defn poorly-formatted-fn[x]( + x 5) )"
           result (file-write-core/write-clojure-file
-                   test-utils/*nrepl-client-atom*
-                   path
-                   unformatted-content)]
+                  test-utils/*nrepl-client-atom*
+                  path
+                  unformatted-content)]
       (is (not (:error result)))
       (is (= "update" (:type result)))
       (is (not (str/includes? (slurp *test-clj-file*) "poorly-formatted-fn[x]")))
@@ -123,9 +123,9 @@
     (let [path (.getPath *test-clj-file*)
           content-with-missing-paren "(ns test.namespace)\n\n(defn repaired-function [x]\n  (+ x 10)"
           result (file-write-core/write-clojure-file
-                   test-utils/*nrepl-client-atom*
-                   path
-                   content-with-missing-paren)]
+                  test-utils/*nrepl-client-atom*
+                  path
+                  content-with-missing-paren)]
       (is (not (:error result)))
       (is (= "update" (:type result)))
       (let [saved-content (slurp *test-clj-file*)]
@@ -137,9 +137,9 @@
     (let [path (.getPath *test-clj-file*)
           content-with-mismatched-brackets "(ns test.namespace)\n\n(defn bracket-fn [x]\n  (let [y (+ x 1)]\n    (println y]))"
           result (file-write-core/write-clojure-file
-                   test-utils/*nrepl-client-atom*
-                   path
-                   content-with-mismatched-brackets)]
+                  test-utils/*nrepl-client-atom*
+                  path
+                  content-with-mismatched-brackets)]
       (is (not (:error result)))
       (is (= "update" (:type result)))
       (let [saved-content (slurp *test-clj-file*)]
@@ -152,9 +152,9 @@
           content-with-syntax-error "(ns test.namespace)\n\n(defn broken-function a123 [x 11)\n  (+ x 10))"
           original-content (slurp *test-clj-file*)
           result (file-write-core/write-clojure-file
-                   test-utils/*nrepl-client-atom*
-                   path
-                   content-with-syntax-error)]
+                  test-utils/*nrepl-client-atom*
+                  path
+                  content-with-syntax-error)]
       ;; The test should fail with a specific error
       (is (:error result) "Should have error for non-repairable syntax error")
       (when (:message result)

--- a/test/clojure_mcp/tools/form_edit/core_test.clj
+++ b/test/clojure_mcp/tools/form_edit/core_test.clj
@@ -1,5 +1,7 @@
 (ns clojure-mcp.tools.form-edit.core-test
   (:require
+   [clojure-mcp.tools.test-utils :as test-utils]
+   [clojure-mcp.config :as config]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [clojure-mcp.tools.form-edit.core :as sut]
    [rewrite-clj.zip :as z]
@@ -18,12 +20,14 @@
       (spit test-file "(ns test.core)\n\n(defn example-fn [x y]\n  #_(println \"debug value:\" x)\n  (+ x y))\n\n(def a 1)\n\n#_(def unused-value 42)\n\n(comment\n  (example-fn 1 2))\n\n;; Test comment\n;; spans multiple lines")
       (binding [*test-dir* test-dir
                 *test-file* test-file]
+        (config/set-config! test-utils/*nrepl-client-atom* :nrepl-user-dir test-dir)
         (try
           (f)
           (finally
             (when (.exists test-file) (.delete test-file))
             (when (.exists test-dir) (.delete test-dir))))))))
 
+(use-fixtures :once test-utils/test-nrepl-fixture)
 (use-fixtures :each create-test-files-fixture)
 
 ;; Test helper functions
@@ -310,6 +314,15 @@
                      sut/default-formatting-options)]
       ;; Compare as EDN to ignore whitespace differences
       (is (= (read-string unformatted) (read-string formatted))))))
+
+(deftest project-formatting-options-test
+  (testing "format-source-string correctly formats source code"
+    (let [custom-options {:function-arguments-indentation :cursive}
+          _ (spit (io/file *test-dir* "cljfmt.edn") (pr-str custom-options))
+          formatting-options (sut/project-formatting-options
+                              @test-utils/*nrepl-client-atom*)]
+      (is (= (merge sut/default-formatting-options custom-options)
+             formatting-options)))))
 
 (deftest load-file-content-test
   (testing "load-file-content loads existing file"

--- a/test/clojure_mcp/tools/form_edit/core_test.clj
+++ b/test/clojure_mcp/tools/form_edit/core_test.clj
@@ -305,7 +305,9 @@
 (deftest format-source-string-test
   (testing "format-source-string correctly formats source code"
     (let [unformatted "(defn   example-fn[x y]  (+ x  y)   )"
-          formatted (sut/format-source-string unformatted)]
+          formatted (sut/format-source-string
+                     unformatted
+                     sut/default-formatting-options)]
       ;; Compare as EDN to ignore whitespace differences
       (is (= (read-string unformatted) (read-string formatted))))))
 

--- a/test/clojure_mcp/tools/form_edit/pipeline_test.clj
+++ b/test/clojure_mcp/tools/form_edit/pipeline_test.clj
@@ -1,6 +1,7 @@
 (ns clojure-mcp.tools.form-edit.pipeline-test
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
+   [clojure-mcp.config :as config]
    [clojure-mcp.tools.form-edit.pipeline :as sut]
    [clojure-mcp.tools.form-edit.core :as core]
    [clojure-mcp.tools.test-utils :as test-utils]
@@ -11,7 +12,6 @@
 ;; Test fixtures
 (def ^:dynamic *test-dir* nil)
 (def ^:dynamic *test-file* nil)
-
 (def ^:dynamic *nrepl-client-atom* nil)
 
 (defn create-test-files-fixture [f]
@@ -29,6 +29,7 @@
                           test-file-content)]
       (binding [*test-dir* test-dir
                 *test-file* (io/file test-file-path)]
+        (config/set-config! test-utils/*nrepl-client-atom* :nrepl-user-dir test-dir)
         (try
           (f)
           (finally

--- a/test/clojure_mcp/tools/form_edit/pipeline_test.clj
+++ b/test/clojure_mcp/tools/form_edit/pipeline_test.clj
@@ -175,7 +175,8 @@
   (testing "format-source formats the source code"
     ;; Manual setup to avoid dependency on zloc->output-source
     (let [source "(ns test.core)\n\n(defn  example-fn[x y]   (+ x y))"
-          ctx {::sut/output-source source} ;; Directly use the source as output source
+          ctx {::sut/nrepl-client-atom *nrepl-client-atom*
+               ::sut/output-source source} ;; Directly use the source as output source
           result (sut/format-source ctx)]
       (is (string? (::sut/output-source result)))
       (is (not (str/includes? (::sut/output-source result) "  example-fn[x y]")))

--- a/test/clojure_mcp/tools/test_utils.clj
+++ b/test/clojure_mcp/tools/test_utils.clj
@@ -16,8 +16,7 @@
 (defn test-nrepl-fixture [f]
   (let [server (nrepl-server/start-server :port 0) ; Use port 0 for dynamic port assignment
         port (:port server)
-        client (-> (nrepl/create {:port port})
-                   (assoc ::config/config {:nrepl-user-dir "."}))
+        client (nrepl/create {:port port})
         client-atom (atom client)]
     (nrepl/start-polling client)
     (nrepl/eval-code client "(require 'clojure.repl)" identity)

--- a/test/clojure_mcp/tools/test_utils.clj
+++ b/test/clojure_mcp/tools/test_utils.clj
@@ -1,6 +1,7 @@
 (ns clojure-mcp.tools.test-utils
   "Utility functions for testing the tool-system based tools."
   (:require
+   [clojure-mcp.config :as config]
    [clojure-mcp.nrepl :as nrepl]
    [nrepl.server :as nrepl-server]
    [clojure-mcp.tool-system :as tool-system]
@@ -15,7 +16,8 @@
 (defn test-nrepl-fixture [f]
   (let [server (nrepl-server/start-server :port 0) ; Use port 0 for dynamic port assignment
         port (:port server)
-        client (nrepl/create {:port port})
+        client (-> (nrepl/create {:port port})
+                   (assoc ::config/config {:nrepl-user-dir "."}))
         client-atom (atom client)]
     (nrepl/start-polling client)
     (nrepl/eval-code client "(require 'clojure.repl)" identity)


### PR DESCRIPTION
Resolves #20.

Confirmed tests are passing locally with `clojure -M:test`.