### PR TITLE
Fix eval tool error reporting

### DIFF
--- a/src/clojure_mcp/tools/eval/core.clj
+++ b/src/clojure_mcp/tools/eval/core.clj
@@ -93,9 +93,9 @@
                               (deliver result-promise
                                        {:outputs @outputs
                                         :error @error-occurred})))
-                (nrepl/error (fn [_]
+                (nrepl/error (fn [{:keys [exception]}]
                                (reset! error-occurred true)
-                               (add-output! :err "Evaluation failed")
+                               (add-output! :err exception)
                                (deliver result-promise
                                         {:outputs @outputs
                                          :error true})))))
@@ -145,11 +145,11 @@
   ;; === Examples of using the eval core functionality directly ===
 
   ;; Setup for REPL-based testing
-  (def client-atom (atom (clojure-mcp.nrepl/create {:port 7888})))
+  (def client-atom (atom (clojure-mcp.nrepl/create {:port 44833})))
   (clojure-mcp.nrepl/start-polling @client-atom)
 
   ;; Test simple expression evaluation with options map
-  (evaluate-code @client-atom {:code "(+ 1 2)"})
+  (evaluate-code @client-atom {:code "(println hello_world)"})
 
   ;; Test with namespace option
   (evaluate-code @client-atom {:code "(str *ns*)" :namespace "clojure.string"})

--- a/src/clojure_mcp/tools/eval/core.clj
+++ b/src/clojure_mcp/tools/eval/core.clj
@@ -145,7 +145,7 @@
   ;; === Examples of using the eval core functionality directly ===
 
   ;; Setup for REPL-based testing
-  (def client-atom (atom (clojure-mcp.nrepl/create {:port 44833})))
+  (def client-atom (atom (clojure-mcp.nrepl/create {:port 7888})))
   (clojure-mcp.nrepl/start-polling @client-atom)
 
   ;; Test simple expression evaluation with options map

--- a/src/clojure_mcp/tools/eval/core.clj
+++ b/src/clojure_mcp/tools/eval/core.clj
@@ -149,7 +149,7 @@
   (clojure-mcp.nrepl/start-polling @client-atom)
 
   ;; Test simple expression evaluation with options map
-  (evaluate-code @client-atom {:code "(println hello_world)"})
+  (evaluate-code @client-atom {:code "(+ 1 2)"})
 
   ;; Test with namespace option
   (evaluate-code @client-atom {:code "(str *ns*)" :namespace "clojure.string"})

--- a/src/clojure_mcp/tools/eval/tool.clj
+++ b/src/clojure_mcp/tools/eval/tool.clj
@@ -71,7 +71,7 @@ Examples:
 (defmethod tool-system/format-results ::clojure-eval [_ {:keys [outputs error repaired] :as eval-result}]
   ;; The core implementation now returns a map with :outputs (raw outputs), :error (boolean), and :repaired (boolean)
   ;; We need to format the outputs and return a map with :result, :error, and :repaired
-  {:result [(string/join "\n" (core/partition-and-format-outputs outputs))]
+  {:result (core/partition-and-format-outputs outputs)
    :error error
    :repaired repaired})
 


### PR DESCRIPTION
## Summary
- Replace generic "Evaluation failed" message with detailed exception information

## Problem
The eval tool was returning unhelpful generic error messages for all types of evaluation failures, making debugging difficult and reducing the LLM's ability to provide accurate assistance.

## Solution
- Modified error handler to capture and include exception details from nREPL response
- Preserves all existing functionality while providing much more useful error information
- Does not use string joining

## Before vs After

### Before (generic error):
```clojure
● clojure-mcp:clojure_eval (MCP)(code: "(/ 1 0)")
  ⎿  Error: Evaluation failed
```

### After (detailed errors):

**Division by zero:**
```
● clojure-mcp:clojure_eval (MCP)(code: "(/ 1 0)")
  ⎿  Error: {:via [{:type java.lang.ArithmeticException, :message "Divide by zero", :at 
     [clojure.lang.Numbers divide "Numbers.java" 190]}], :trace [[clojure.lang.Numbers divide 
     "Numbers.java" 190] [clojure.lang.Numbers divide "Numbers.java" 3915] [user$eval2235 
     invokeStatic "form-init18174217600633107492.clj" 1] [user$eval2235 invoke 
     "form-init18174217600633107492.clj" 1] [clojure.lang.Compiler eval "Compiler.java" 7700] 
     [clojure.lang.Compiler eval "Compiler.java" 7655] [clojure.core$eval invokeStatic "core.clj" 
     3232] [clojure.core$eval invoke "core.clj" 3228] 
     [nrepl.middleware.interruptible_eval$evaluate$fn__966$fn__967 invoke "interruptible_eval.clj" 
     87] [clojure.lang.AFn applyToHelper "AFn.java" 152] [clojure.lang.AFn applyTo "AFn.java" 144] 
     [clojure.core$apply invokeStatic "core.clj" 667] [clojure.core$with_bindings_STAR_ 
     invokeStatic "core.clj" 1990] [clojure.core$with_bindings_STAR_ doInvoke "core.clj" 1990] 
     [clojure.lang.RestFn invoke "RestFn.java" 428] 
     [nrepl.middleware.interruptible_eval$evaluate$fn__966 invoke "interruptible_eval.clj" 87] 
     [clojure.main$repl$read_eval_print__9244$fn__9247 invoke "main.clj" 437] 
     [clojure.main$repl$read_eval_print__9244 invoke "main.clj" 437] [clojure.main$repl$fn__9253 
     invoke "main.clj" 459] [clojure.main$repl invokeStatic "main.clj" 459] [clojure.main$repl 
     doInvoke "main.clj" 368] [clojure.lang.RestFn invoke "RestFn.java" 1526] 
     [nrepl.middleware.interruptible_eval$evaluate invokeStatic "interruptible_eval.clj" 84] 
     [nrepl.middleware.interruptible_eval$evaluate invoke "interruptible_eval.clj" 56] 
     [nrepl.middleware.interruptible_eval$interruptible_eval$fn__997$fn__1001 invoke 
     "interruptible_eval.clj" 152] [clojure.lang.AFn run "AFn.java" 22] 
     [nrepl.middleware.session$session_exec$main_loop__1065$fn__1069 invoke "session.clj" 202] 
     [nrepl.middleware.session$session_exec$main_loop__1065 invoke "session.clj" 201] 
     [clojure.lang.AFn run "AFn.java" 22] [java.lang.Thread run "Thread.java" 1447]], :cause 
     "Divide by zero", :clojure.error/phase :execution}
```

**Undefined symbol:**
```
● clojure-mcp:clojure_eval (MCP)(code: "(println hello_world)")
  ⎿  Error: {:via [{:type clojure.lang.Compiler$CompilerException, :message "Syntax error compiling
      at (/tmp/form-init18174217600633107492.clj:1:1).", :data #:clojure.error{:phase 
     :compile-syntax-check, :line 1, :column 1, :source "/tmp/form-init18174217600633107492.clj"}, 
     :at [clojure.lang.Compiler analyze "Compiler.java" 7340]} {:type java.lang.RuntimeException, 
     :message "Unable to resolve symbol: hello_world in this context", :at [clojure.lang.Util 
     runtimeException "Util.java" 221]}], :trace [[clojure.lang.Util runtimeException "Util.java" 
     221] [clojure.lang.Compiler resolveIn "Compiler.java" 7944] [clojure.lang.Compiler resolve 
     "Compiler.java" 7883] [clojure.lang.Compiler analyzeSymbol "Compiler.java" 7844] 
     [clojure.lang.Compiler analyze "Compiler.java" 7300] [clojure.lang.Compiler analyze 
     "Compiler.java" 7277] [clojure.lang.Compiler$InvokeExpr parse "Compiler.java" 4371] 
     [clojure.lang.Compiler analyzeSeq "Compiler.java" 7632] [clojure.lang.Compiler analyze 
     "Compiler.java" 7321] [clojure.lang.Compiler analyze "Compiler.java" 7277] 
     [clojure.lang.Compiler$BodyExpr$Parser parse "Compiler.java" 6644] 
     [clojure.lang.Compiler$FnMethod parse "Compiler.java" 5983] [clojure.lang.Compiler$FnExpr 
     parse "Compiler.java" 4546] [clojure.lang.Compiler analyzeSeq "Compiler.java" 7628] 
     [clojure.lang.Compiler analyze "Compiler.java" 7321] [clojure.lang.Compiler eval 
     "Compiler.java" 7697] [clojure.lang.Compiler eval "Compiler.java" 7655] [clojure.core$eval 
     invokeStatic "core.clj" 3232] [clojure.core$eval invoke "core.clj" 3228] 
     [nrepl.middleware.interruptible_eval$evaluate$fn__966$fn__967 invoke "interruptible_eval.clj" 
     87] [clojure.lang.AFn applyToHelper "AFn.java" 152] [clojure.lang.AFn applyTo "AFn.java" 144] 
     [clojure.core$apply invokeStatic "core.clj" 667] [clojure.core$with_bindings_STAR_ 
     invokeStatic "core.clj" 1990] [clojure.core$with_bindings_STAR_ doInvoke "core.clj" 1990] 
     [clojure.lang.RestFn invoke "RestFn.java" 428] 
     [nrepl.middleware.interruptible_eval$evaluate$fn__966 invoke "interruptible_eval.clj" 87] 
     [clojure.main$repl$read_eval_print__9244$fn__9247 invoke "main.clj" 437] 
     [clojure.main$repl$read_eval_print__9244 invoke "main.clj" 437] [clojure.main$repl$fn__9253 
     invoke "main.clj" 459] [clojure.main$repl invokeStatic "main.clj" 459] [clojure.main$repl 
     doInvoke "main.clj" 368] [clojure.lang.RestFn invoke "RestFn.java" 1526] 
     [nrepl.middleware.interruptible_eval$evaluate invokeStatic "interruptible_eval.clj" 84] 
     [nrepl.middleware.interruptible_eval$evaluate invoke "interruptible_eval.clj" 56] 
     [nrepl.middleware.interruptible_eval$interruptible_eval$fn__997$fn__1001 invoke 
     "interruptible_eval.clj" 152] [clojure.lang.AFn run "AFn.java" 22] 
     [nrepl.middleware.session$session_exec$main_loop__1065$fn__1069 invoke "session.clj" 202] 
     [nrepl.middleware.session$session_exec$main_loop__1065 invoke "session.clj" 201] 
     [clojure.lang.AFn run "AFn.java" 22] [java.lang.Thread run "Thread.java" 1447]], :cause 
     "Unable to resolve symbol: hello_world in this context", :phase :compile-syntax-check, 
     :clojure.error/phase :compile-syntax-check
```

**Wrong arity:**
```
● clojure-mcp:clojure_eval (MCP)(code: "(first)")
  ⎿  Error: {:via [{:type clojure.lang.ArityException, :message "Wrong number of args (0) passed 
     to: clojure.core/first--5468", :at [clojure.lang.AFn throwArity "AFn.java" 429]}], :trace 
     [[clojure.lang.AFn throwArity "AFn.java" 429] [clojure.lang.AFn invoke "AFn.java" 28] 
     [user$eval2238 invokeStatic "form-init18174217600633107492.clj" 1] [user$eval2238 invoke 
     "form-init18174217600633107492.clj" 1] [clojure.lang.Compiler eval "Compiler.java" 7700] 
     [clojure.lang.Compiler eval "Compiler.java" 7655] [clojure.core$eval invokeStatic "core.clj" 
     3232] [clojure.core$eval invoke "core.clj" 3228] 
     [nrepl.middleware.interruptible_eval$evaluate$fn__966$fn__967 invoke "interruptible_eval.clj" 
     87] [clojure.lang.AFn applyToHelper "AFn.java" 152] [clojure.lang.AFn applyTo "AFn.java" 144] 
     [clojure.core$apply invokeStatic "core.clj" 667] [clojure.core$with_bindings_STAR_ 
     invokeStatic "core.clj" 1990] [clojure.core$with_bindings_STAR_ doInvoke "core.clj" 1990] 
     [clojure.lang.RestFn invoke "RestFn.java" 428] 
     [nrepl.middleware.interruptible_eval$evaluate$fn__966 invoke "interruptible_eval.clj" 87] 
     [clojure.main$repl$read_eval_print__9244$fn__9247 invoke "main.clj" 437] 
     [clojure.main$repl$read_eval_print__9244 invoke "main.clj" 437] [clojure.main$repl$fn__9253 
     invoke "main.clj" 459] [clojure.main$repl invokeStatic "main.clj" 459] [clojure.main$repl 
     doInvoke "main.clj" 368] [clojure.lang.RestFn invoke "RestFn.java" 1526] 
     [nrepl.middleware.interruptible_eval$evaluate invokeStatic "interruptible_eval.clj" 84] 
     [nrepl.middleware.interruptible_eval$evaluate invoke "interruptible_eval.clj" 56] 
     [nrepl.middleware.interruptible_eval$interruptible_eval$fn__997$fn__1001 invoke 
     "interruptible_eval.clj" 152] [clojure.lang.AFn run "AFn.java" 22] 
     [nrepl.middleware.session$session_exec$main_loop__1065$fn__1069 invoke "session.clj" 202] 
     [nrepl.middleware.session$session_exec$main_loop__1065 invoke "session.clj" 201] 
     [clojure.lang.AFn run "AFn.java" 22] [java.lang.Thread run "Thread.java" 1447]], :cause "Wrong
      number of args (0) passed to: clojure.core/first--5468", :clojure.error/phase :execution}
```

## Test plan
- [x] Test division by zero: `(/ 1 0)` - now returns detailed ArithmeticException
- [x] Test undefined symbols: returns specific CompilerException details  
- [x] Test wrong arity: returns specific arity error messages
- [x] Verify existing successful evaluations still work correctly

Fixes #27

🤖 Generated with [Claude Code](https://claude.ai/code)