### PR TITLE
Fix NPE in `close-servers` when mcp-server is not initialized

### DIFF
--- a/src/clojure_mcp/core.clj
+++ b/src/clojure_mcp/core.clj
@@ -314,9 +314,10 @@
     (when-let [client @nrepl-client-atom]
       (log/info "Stopping nREPL polling")
       (nrepl/stop-polling client)
-      (log/info "Closing MCP server gracefully")
-      (.closeGracefully (:mcp-server client))
-      (log/info "Servers shut down successfully"))
+      (when-let [mcp-server (:mcp-server client)]
+        (log/info "Closing MCP server gracefully")
+        (.closeGracefully mcp-server)
+        (log/info "Servers shut down successfully")))
     (catch Exception e
       (log/error e "Error during server shutdown")
       (throw e))))


### PR DESCRIPTION
The `close-servers` helper function ensures all state in `nrepl-client-atom` is properly closed. However, it currently throws a NPE when attempting to close a `nrepl-client-atom` with a mcp-server that was never started.

**Problem:**
When `close-servers` is called and no mcp-server exists in the state atom, the `closeGracefully` call fails with an NPE.

**Solution:**
Only attempt closing the mcp-server if it exists in the state.