### PR TITLE
Allow user-dir override for working with docker based nrepl environments

### DIFF
--- a/DOCKER_USAGE.md
+++ b/DOCKER_USAGE.md
@@ -1,0 +1,108 @@
+# Docker Usage with Clojure MCP
+
+This document explains how to use Clojure MCP when your nREPL server runs in a Docker container but the MCP server runs on the host.
+
+## Overview
+
+When running nREPL in Docker, the container reports its working directory as `/app` (or similar), while the MCP server running on the host needs to work with host filesystem paths. Clojure MCP supports a `:user-dir-override` parameter that allows you to specify the host filesystem path while connecting to a Docker-based nREPL.
+
+This enables a flexible development setup where:
+
+- Your Clojure environment runs in a consistent Docker container
+- The MCP server runs on the host with access to your editor/IDE
+- File operations work seamlessly between both environments
+
+## Setup Examples
+
+### Basic Docker Setup
+
+1. **Start your nREPL in Docker**:
+
+```bash
+# In your project directory
+docker run -v $(pwd):/app -p 7888:7888 clojure:openjdk-11-tools-deps \
+  clojure -M:dkr-nrepl
+```
+
+2. **Start the MCP server on host** with directory override:
+
+**From Terminal:**
+```bash
+# Using the override parameter
+clojure -X:mcp :port 7888 :user-dir-override "$(pwd)"
+````
+
+**From Cursor:**
+
+`<project_root>/.cursor/mcp.json` (note that `"."` expands to the project directory)
+```json
+{
+    "mcpServers": {
+        "clojure-mcp": {
+            "command": "sh",
+            "args": [
+                "<project_root>/mcp-docker.sh",
+                "7888",
+                "."
+            ]
+        }
+    }
+}
+```
+
+`<project_root>/mcp-docker.sh`
+
+```bash
+#!/bin/bash
+
+PORT=${1:-7888}
+PATH_OVERRIDE=${2:-$(pwd)}
+exec clojure -X:mcp :port "$PORT" :user-dir-override "\"$PATH_OVERRIDE\""
+```
+
+### Docker Compose Setup
+
+Create a `docker-compose.yml`:
+
+```yaml
+version: '3.8'
+services:
+  clojure-nrepl:
+    image: clojure:openjdk-11-tools-deps
+    working_dir: /app
+    volumes:
+      - .:/app
+    ports:
+      - "7888:7888"
+    command:
+      - "clojure"
+      - "-M:dkr-nrepl"
+      - "--bind"
+      - "0.0.0.0"
+      - "--port"
+      - "7888"
+```
+
+Then start services:
+
+```bash
+# Start Docker services
+docker-compose up -d
+```
+
+
+## How It Works
+
+- **Docker nREPL**: Reports working directory as `/app` and handles code evaluation
+- **Host MCP Server**: Uses the override path (e.g., `/Users/you/project`) for file operations
+- **File Synchronization**: Docker volume mount ensures both environments see the same files
+- **Seamless Integration**: MCP server automatically uses the correct paths for the host filesystem
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Path doesn't exist**: Ensure the override path exists on the host filesystem
+2. **Permission issues**: Verify the MCP server has read/write access to the override directory
+3. **Volume mounting**: Confirm Docker volume mounts are configured correctly so both environments access the same files
+

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ If you see output other than JSON-RPC messages, it's likely due to `clojure-mcp`
 
 - **Location Independence**: The MCP server can run from any directory—it doesn't need to be in your project directory. It uses the nREPL connection for context.
 - **Shared Filesystem**: Currently, the nREPL and MCP servers must run on the same machine as they assume a shared filesystem.
+- **Docker Support**: If your nREPL runs in Docker but MCP server runs on the host, use the `:user-dir-override` parameter to specify the host filesystem path. See [DOCKER_USAGE.md](DOCKER_USAGE.md) for detailed setup instructions.
 - **Dependency Isolation**: Don't include `clojure-mcp` in your project's dependencies. It should run separately with its own deps. Always use `:deps` (not `:extra-deps`) in its alias.
 
 ## Step 3: Configure Claude Desktop

--- a/src/clojure_mcp/main.clj
+++ b/src/clojure_mcp/main.clj
@@ -121,7 +121,9 @@
 
 ;; start the server
 (defn start-mcp-server [nrepl-args]
-  ;; the nrepl-args are a map with :port :host :tls-keys-file]
+  ;; the nrepl-args are a map with :port :host :tls-keys-file
+  ;; can also include :user-dir-override for Docker setups where nREPL runs in container
+  ;; but MCP server runs on host
   (let [nrepl-client-map (core/create-and-start-nrepl-connection nrepl-args)
         working-dir (config/get-nrepl-user-dir nrepl-client-map)
         resources (my-resources nrepl-client-map working-dir)

--- a/src/clojure_mcp/main_examples/figwheel_main.clj
+++ b/src/clojure_mcp/main_examples/figwheel_main.clj
@@ -1,5 +1,5 @@
 (ns clojure-mcp.main-examples.figwheel-main
-  (:require 
+  (:require
    [clojure-mcp.core :as core]
    [clojure-mcp.config :as config]
    [clojure-mcp.main :as main]
@@ -33,6 +33,7 @@
 ;; start the server
 (defn start-mcp-server [nrepl-args]
   ;; the nrepl-args are a map with :port :host :figwheel-build
+  ;; can also include :user-dir-override for Docker setups
   (let [nrepl-client-map (core/create-and-start-nrepl-connection nrepl-args)
         working-dir (config/get-nrepl-user-dir nrepl-client-map)
         resources (main/my-resources nrepl-client-map working-dir)

--- a/src/clojure_mcp/main_examples/shadow_main.clj
+++ b/src/clojure_mcp/main_examples/shadow_main.clj
@@ -1,5 +1,5 @@
 (ns clojure-mcp.main-examples.shadow-main
-  (:require 
+  (:require
    [clojure-mcp.core :as core]
    [clojure-mcp.config :as config]
    [clojure-mcp.nrepl :as nrepl]
@@ -78,6 +78,7 @@ JavaScript interop is fully supported including `js/console.log`, `js/setTimeout
 ;; start the server
 (defn start-mcp-server [nrepl-args]
   ;; the nrepl-args are a map with :port :host :figwheel-build
+  ;; can also include :user-dir-override for Docker setups
   (let [nrepl-client-map (core/create-and-start-nrepl-connection nrepl-args)
         working-dir (config/get-nrepl-user-dir nrepl-client-map)
         resources (main/my-resources nrepl-client-map working-dir)

--- a/src/clojure_mcp/sse_main.clj
+++ b/src/clojure_mcp/sse_main.clj
@@ -10,6 +10,7 @@
 
 (defn start-sse-mcp-server [args]
   ;; the nrepl-args are a map with :port :host
+  ;; can also include :user-dir-override for Docker setups
   ;; we also need an :mcp-sse-port so we'll default to 8078??
   (let [mcp-port (:mcp-sse-port args 8078)
         nrepl-client-map (core/create-and-start-nrepl-connection args)
@@ -18,7 +19,7 @@
         _ (reset! nrepl-client-atom nrepl-client-map)
         tools (main/my-tools nrepl-client-atom)
         prompts (main/my-prompts working-dir)
-        {:keys [mcp-server provider-servlet] } (sse-core/mcp-sse-server)]
+        {:keys [mcp-server provider-servlet]} (sse-core/mcp-sse-server)]
     (doseq [tool tools]
       (core/add-tool mcp-server tool))
     (doseq [resource resources]


### PR DESCRIPTION
## Add Docker Support with User Directory Override

### Summary
Adds `:user-dir-override` parameter to enable Docker workflows where nREPL runs in container but MCP server runs on host.

### Problem
Docker nREPL reports working directory as `/app`, but host MCP server needs actual host filesystem paths, causing configuration assertion failures.

### Solution
- Added `:user-dir-override` parameter to `create-and-start-nrepl-connection`
- Optimized to skip nREPL query when override provided
- Added comprehensive Docker documentation (`DOCKER_USAGE.md`)

### Usage
```bash
# Terminal
clojure -X:mcp :port 7888 :user-dir-override "$(pwd)"

# Cursor
{
  "mcpServers": {
    "clojure-mcp": {
      "command": "sh",
      "args": ["<project_root>/mcp-docker.sh", "7888", "."]
    }
  }
}
```

**mcp-docker.sh:**
```bash
#!/bin/bash
PORT=${1:-7888}
PATH_OVERRIDE=${2:-$(pwd)}
exec clojure -X:mcp :port "$PORT" :user-dir-override "\"$PATH_OVERRIDE\""
```

### Benefits
- Enables containerized Clojure development with host IDE integration
- Fully backward compatible (parameter is optional)
- Performance optimized (avoids unnecessary nREPL calls)