### PR TITLE
Verify validated-path exists in unified-file-read

### DIFF
--- a/src/clojure_mcp/tools/unified_read_file/tool.clj
+++ b/src/clojure_mcp/tools/unified_read_file/tool.clj
@@ -108,11 +108,6 @@ By default, reads up to " max-lines " lines, truncating lines longer than " max-
     (when-not path
       (throw (ex-info "Missing required parameter: path" {:inputs inputs})))
 
-    (when-not (valid-paths/path-exists? path)
-      (throw
-       (ex-info (format "Invalid Path: file `%s` does not exist." path)
-               {:inputs inputs})))
-
     (when (and name_pattern (not= name_pattern ""))
       (try (re-pattern name_pattern)
            (catch Exception e
@@ -126,6 +121,12 @@ By default, reads up to " max-lines " lines, truncating lines longer than " max-
                              {:pattern content_pattern})))))
 
     (let [validated-path (valid-paths/validate-path-with-client path nrepl-client)]
+
+      (when-not (valid-paths/path-exists? validated-path)
+        (throw
+          (ex-info (format "Invalid Path: file `%s` does not exist." path)
+            {:inputs inputs})))
+
       {:path validated-path
        :collapsed (if (nil? collapsed) true collapsed)
        :name_pattern name_pattern


### PR DESCRIPTION
## Problem 

The unified-file-read tool checks that `path` exists before validating it with the nrepl client. This incorrect order allows the tool to be invoked from outside permitted directories and prevents the path from being properly relativized to the nrepl's working directory.

## Solution

Move the check inside the `let` block where `validated-path` exists. This behavior is consistent with other tools like read_file and write_file. 