### PR TITLE
Expand clojure-file? to include .edn and .bb files

### DIFF
--- a/src/clojure_mcp/tools/file_write/core.clj
+++ b/src/clojure_mcp/tools/file_write/core.clj
@@ -15,11 +15,11 @@
    Parameters:
    - file-path: Path to the file to check
    
-   Returns true if the file has a Clojure-related extension (.clj, .cljs, .cljc, .edn),
+   Returns true if the file has a Clojure-related extension (.clj, .cljs, .cljc, .edn, .bb),
    false otherwise."
   [file-path]
   (let [lower-path (string/lower-case file-path)]
-    (some #(string/ends-with? lower-path %) [".clj" ".cljs" ".cljc" ".edn"])))
+    (some #(string/ends-with? lower-path %) [".clj" ".cljs" ".cljc" ".edn" ".bb"])))
 
 (defn write-clojure-file
   "Write content to a Clojure file, with linting, formatting, and diffing.

--- a/src/clojure_mcp/tools/unified_read_file/tool.clj
+++ b/src/clojure_mcp/tools/unified_read_file/tool.clj
@@ -36,7 +36,7 @@
   [file-path]
   (when file-path
     (let [extension (last (str/split file-path #"\."))]
-      (contains? #{"clj" "cljc" "cljs"} extension))))
+      (contains? #{"clj" "cljc" "cljs" "edn" "bb"} extension))))
 
 ;; Implement the required multimethods for the unified read file tool
 (defmethod tool-system/tool-name :unified-read-file [_]
@@ -45,7 +45,7 @@
 (defmethod tool-system/tool-description :unified-read-file [{:keys [max-lines max-line-length]}]
   (str "Smart file reader with pattern-based exploration for Clojure files.
    
-For Clojure files (.clj, .cljc, .cljs):
+For Clojure files (.clj, .cljc, .cljs, .edn, .bb):
 
 This tool defaults to an expandable collapsed view to quickly grab the information you need from a Clojure file.
 If called without `name_pattern` or `content_pattern` it will return the file content where 

--- a/src/clojure_mcp/tools/unified_read_file/tool.clj
+++ b/src/clojure_mcp/tools/unified_read_file/tool.clj
@@ -31,12 +31,12 @@
 
  ;; Helper functions
 
-(defn clojure-file?
-  "Determines if a file is a Clojure source file based on its extension."
+(defn collapsible-clojure-file?
+  "Determines if a file is a collapsible Clojure source file based on its extension."
   [file-path]
   (when file-path
     (let [extension (last (str/split file-path #"\."))]
-      (contains? #{"clj" "cljc" "cljs" "edn" "bb"} extension))))
+      (contains? #{"clj" "cljc" "cljs" "bb"} extension))))
 
 ;; Implement the required multimethods for the unified read file tool
 (defmethod tool-system/tool-name :unified-read-file [_]
@@ -45,7 +45,7 @@
 (defmethod tool-system/tool-description :unified-read-file [{:keys [max-lines max-line-length]}]
   (str "Smart file reader with pattern-based exploration for Clojure files.
    
-For Clojure files (.clj, .cljc, .cljs, .edn, .bb):
+For Clojure files (.clj, .cljc, .cljs, .bb):
 
 This tool defaults to an expandable collapsed view to quickly grab the information you need from a Clojure file.
 If called without `name_pattern` or `content_pattern` it will return the file content where 
@@ -138,7 +138,7 @@ By default, reads up to " max-lines " lines, truncating lines longer than " max-
 (defmethod tool-system/execute-tool :unified-read-file [{:keys [max-lines max-line-length nrepl-client-atom]} inputs]
   (let [{:keys [path collapsed name_pattern content_pattern include_comments line_offset limit]} inputs
         limit-val (or limit max-lines)
-        is-clojure-file (clojure-file? path)
+        is-clojure-file (collapsible-clojure-file? path)
         ;; Get write-file-guard config if we have the atom
         write-file-guard (when nrepl-client-atom
                            (config/get-write-file-guard @nrepl-client-atom))]

--- a/test/clojure_mcp/tools/file_write/core_test.clj
+++ b/test/clojure_mcp/tools/file_write/core_test.clj
@@ -49,6 +49,7 @@
     (is (file-write-core/is-clojure-file? "test.cljs"))
     (is (file-write-core/is-clojure-file? "test.cljc"))
     (is (file-write-core/is-clojure-file? "test.edn"))
+    (is (file-write-core/is-clojure-file? "test.bb"))
     (is (file-write-core/is-clojure-file? "/path/to/file.clj"))
     (is (file-write-core/is-clojure-file? "C:\\Path\\To\\File.CLJ")) ; Case insensitive
     (is (not (file-write-core/is-clojure-file? "test.txt")))

--- a/test/clojure_mcp/tools/unified_read_file/tool_test.clj
+++ b/test/clojure_mcp/tools/unified_read_file/tool_test.clj
@@ -53,3 +53,15 @@
                       {:path non-existent-path
                        :collapsed false})]
           (is (:error result) "Should return an error for non-existent file"))))))
+
+(deftest collapsible-clojure-file-test
+  (testing "Detecting collapsible Clojure file extensions"
+    (is (unified-read-file-tool/collapsible-clojure-file? "test.clj"))
+    (is (unified-read-file-tool/collapsible-clojure-file? "test.cljs"))
+    (is (unified-read-file-tool/collapsible-clojure-file? "test.cljc"))
+    (is (unified-read-file-tool/collapsible-clojure-file? "test.bb"))
+    (is (unified-read-file-tool/collapsible-clojure-file? "/path/to/file.clj"))
+    (is (not (unified-read-file-tool/collapsible-clojure-file? "test.edn"))) ; EDN files not collapsible
+    (is (not (unified-read-file-tool/collapsible-clojure-file? "test.txt")))
+    (is (not (unified-read-file-tool/collapsible-clojure-file? "test.md")))
+    (is (not (unified-read-file-tool/collapsible-clojure-file? "test.js")))))


### PR DESCRIPTION
- Add .edn and .bb extensions to clojure-file? in unified-read-file/tool.clj
- Add .bb extension to is-clojure-file? in file-write/core.clj (.edn was already there)
- Update test for is-clojure-file? to verify .bb file detection
- Update tool description to list all supported Clojure file types

This fixes mime type detection errors for .edn and .bb files, allowing them to use the collapsed view functionality in the unified-read-file tool.