### PR TITLE
Adding a timeout-ms argument as input of clojure-eval

### DIFF
--- a/src/clojure_mcp/tools/eval/tool.clj
+++ b/src/clojure_mcp/tools/eval/tool.clj
@@ -50,7 +50,9 @@ Examples:
 (defmethod tool-system/tool-schema ::clojure-eval [_]
   {:type :object
    :properties {:code {:type :string
-                       :description "The Clojure code to evaluate."}}
+                       :description "The Clojure code to evaluate."}
+                :timeout-ms {:type :integer
+                             :description "Optional timeout in milliseconds for evaluation."}}
    :required [:code]})
 
 (defmethod tool-system/validate-inputs ::clojure-eval [_ inputs]


### PR DESCRIPTION
I've tried to explicitly set the timeout in my prompt, and since this input was not declared, the model tried:
```json
{
  "code": "something",
  "timeout_ms": "300000"
}
```
which has no effect

and when I tried to force kebab case, it did
```json
{
  "code": "...",
  "timeout-ms": "300000"
}
```
resulting in
```
class java.lang.String cannot be cast to class java.lang.Number (java.lang.String and java.lang.Number are in module java.base of loader 'bootstrap')
```
I couldn't force it to use integers instead of strings.

So just by declaring the input parameter it uses the correct type and now I can run my slow tests :) 