### PR TITLE
fixes #71 - add project info to dispatch agent context

### DIFF
--- a/src/clojure_mcp/main.clj
+++ b/src/clojure_mcp/main.clj
@@ -55,7 +55,7 @@
      "Guidelines for writing Clojure code for the current project hosting the REPL"
      "text/markdown"
      (str working-dir "/LLM_CODE_STYLE.md"))
-    (let [{:keys [outputs error]} (project/inspect-project @nrepl-client-atom)]
+    (let [{:keys [outputs error]} (project/inspect-project nrepl-client-atom)] ; Changed from @nrepl-client-atom
       (when-not error
         (resources/create-string-resource
          "custom://project-info"

--- a/src/clojure_mcp/tools/project/tool.clj
+++ b/src/clojure_mcp/tools/project/tool.clj
@@ -48,8 +48,8 @@ clojure_inspect_project()")
   inputs)
 
 (defmethod tool-system/execute-tool :clojure-inspect-project [{:keys [nrepl-client-atom]} _]
-  ;; Delegate to core implementation
-  (core/inspect-project @nrepl-client-atom))
+  ;; Pass the atom directly to core implementation instead of dereferencing
+  (core/inspect-project nrepl-client-atom))
 
 (defmethod tool-system/format-results :clojure-inspect-project [_ {:keys [outputs error]}]
   ;; Format the results according to MCP expectations
@@ -63,7 +63,7 @@ clojure_inspect_project()")
 (comment
   ;; === Examples of using the project inspection tool ===
   (require 'clojure-mcp.nrepl)
-  
+
   ;; Setup for REPL-based testing
   (def client-atom (atom (clojure-mcp.nrepl/create {:port 7888})))
   (clojure-mcp.nrepl/start-polling @client-atom)

--- a/test/clojure_mcp/tools/project/tool_test.clj
+++ b/test/clojure_mcp/tools/project/tool_test.clj
@@ -95,7 +95,7 @@
 (deftest integration-test-with-real-repl
   (testing "Project inspection with real REPL connection"
     ;; First directly test the inspect-project function
-    (let [direct-result (core/inspect-project @*client-atom*)]
+    (let [direct-result (core/inspect-project *client-atom*)] ; Changed from @*client-atom*
       (is (map? direct-result) "Should return a result map"))
 
     ;; Now test the full tool pipeline


### PR DESCRIPTION
Also made it so that project_info generation only happens once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory initialization now incorporates dynamic project inspection data when available, enhancing the context provided during agent setup.

* **Bug Fixes**
  * Improved caching of project inspection results to reduce repeated computations and improve performance.

* **Tests**
  * Updated tests to reflect changes in how project inspection data is accessed and cached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->