### PR TITLE
Allow clojure_edit to match private def and defn forms

### DIFF
--- a/test/clojure_mcp/tools/form_edit/pipeline_test.clj
+++ b/test/clojure_mcp/tools/form_edit/pipeline_test.clj
@@ -147,6 +147,23 @@
       (is (some? (::sut/zloc result)))
       (is (= 'defn (-> result ::sut/zloc z/down z/sexpr)))))
 
+  (testing "find-form locates private defn and def forms"
+    (let [ctx {::sut/source "(ns test.core)\n\n(defn- hidden [] :secret)\n\n(def- secret 1)"
+               ::sut/top-level-def-type "defn"
+               ::sut/top-level-def-name "hidden"}
+          parsed (sut/parse-source ctx)
+          result (sut/find-form parsed)]
+      (is (some? (::sut/zloc result)))
+      (is (= 'defn- (-> result ::sut/zloc z/down z/sexpr))))
+
+    (let [ctx {::sut/source "(ns test.core)\n\n(defn- hidden [] :secret)\n\n(def- secret 1)"
+               ::sut/top-level-def-type "def"
+               ::sut/top-level-def-name "secret"}
+          parsed (sut/parse-source ctx)
+          result (sut/find-form parsed)]
+      (is (some? (::sut/zloc result)))
+      (is (= 'def- (-> result ::sut/zloc z/down z/sexpr)))))
+
   (testing "find-form returns error for non-existent form"
     (let [ctx {::sut/source "(ns test.core)\n\n(defn example-fn [x y]\n  (+ x y))"
                ::sut/top-level-def-type "defn"


### PR DESCRIPTION
## Summary
- Treat `defn` and `def` form types as matching their private variants (`defn-`/`def-`) when locating or summarizing forms
- Normalize form type handling in summaries to preserve private definition tags
- Add regression tests covering private `defn`/`def` detection in core and pipeline utilities

## Testing
- `clojure -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689118c384bc8330a230d2f487381817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recognition and handling of private variants of top-level forms (e.g., `defn-`, `def-`) alongside their public counterparts.
  * Form summaries now accurately display the exact form type, including any trailing hyphen.

* **Bug Fixes**
  * Enhanced matching logic ensures both public and private forms are consistently identified and summarized.

* **Tests**
  * Added tests to verify correct handling of private forms in top-level form detection, form finding, and summary generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->