### PR TITLE
Detect babashka scripts as Clojure files

### DIFF
--- a/src/clojure_mcp/tools/file_write/core.clj
+++ b/src/clojure_mcp/tools/file_write/core.clj
@@ -2,24 +2,22 @@
   "Core implementation for the file-write tool.
    This namespace contains the pure functionality without any MCP-specific code."
   (:require
-   [clojure.java.io :as io]
-   [clojure.string :as string]
-   [clojure-mcp.tools.form-edit.pipeline :as pipeline]
-   [clojure-mcp.utils.diff :as diff-utils]
-   [clojure-mcp.linting :as linting]
-   [rewrite-clj.zip :as z]))
+    [clojure.java.io :as io]
+    [clojure-mcp.tools.form-edit.pipeline :as pipeline]
+    [clojure-mcp.utils.diff :as diff-utils]
+    [clojure-mcp.linting :as linting]
+    [clojure-mcp.utils.valid-paths :as valid-paths]
+    [rewrite-clj.zip :as z]))
 
-(defn is-clojure-file?
-  "Check if a file is a Clojure-related file based on its extension.
-   
-   Parameters:
-   - file-path: Path to the file to check
-   
-   Returns true if the file has a Clojure-related extension (.clj, .cljs, .cljc, .edn, .bb),
-   false otherwise."
-  [file-path]
-  (let [lower-path (string/lower-case file-path)]
-    (some #(string/ends-with? lower-path %) [".clj" ".cljs" ".cljc" ".edn" ".bb"])))
+  (defn is-clojure-file?
+    "Check if a file is a Clojure-related file based on its extension or Babashka shebang.
+
+     Parameters:
+     - file-path: Path to the file to check
+
+     Returns true for Clojure extensions (.clj, .cljs, .cljc, .edn, .bb) or files with a `bb` shebang."
+    [file-path]
+    (boolean (valid-paths/clojure-file? file-path)))
 
 (defn write-clojure-file
   "Write content to a Clojure file, with linting, formatting, and diffing.

--- a/src/clojure_mcp/tools/unified_read_file/tool.clj
+++ b/src/clojure_mcp/tools/unified_read_file/tool.clj
@@ -30,11 +30,11 @@
  ;; Helper functions
 
 (defn collapsible-clojure-file?
-  "Determines if a file is a collapsible Clojure source file based on its extension."
+  "Determines if a file is a collapsible Clojure source file."
   [file-path]
   (when file-path
-    (let [extension (last (str/split file-path #"\."))]
-      (contains? #{"clj" "cljc" "cljs" "bb" "lpy"} extension))))
+    (and (valid-paths/clojure-file? file-path)
+         (not (str/ends-with? (str/lower-case file-path) ".edn")))))
 
 ;; Implement the required multimethods for the unified read file tool
 (defmethod tool-system/tool-name :unified-read-file [_]

--- a/src/clojure_mcp/utils/valid_paths.clj
+++ b/src/clojure_mcp/utils/valid_paths.clj
@@ -82,24 +82,39 @@
 
     (validate-path path current-dir allowed-dirs)))
 
-(defn clojure-file?
-  "Checks if a file path has a Clojure-related extension.
-   
-   Supported extensions:
-   - .clj (Clojure)
-   - .cljs (ClojureScript)
-   - .cljc (Clojure/ClojureScript shared)
-   - .bb (Babashka)
-   - .edn (Extensible Data Notation)"
-  [file-path]
-  (when file-path
-    (let [lower-path (str/lower-case file-path)]
-      (or (str/ends-with? lower-path ".clj")
-          (str/ends-with? lower-path ".cljs")
-          (str/ends-with? lower-path ".cljc")
-          (str/ends-with? lower-path ".bb")
-          (str/ends-with? lower-path ".lpy")
-          (str/ends-with? lower-path ".edn")))))
+  (defn- babashka-shebang?
+    [file-path]
+    (when (path-exists? file-path)
+      (try
+        (with-open [r (io/reader file-path)]
+          (let [line (-> r line-seq first)]
+            (and line
+                 (or (str/starts-with? line "#!/usr/bin/env bb")
+                     (str/starts-with? line "#!/usr/bin/bb")
+                     (str/starts-with? line "#!/bin/bb")))))
+        (catch Exception _ false))))
+
+  (defn clojure-file?
+    "Checks if a file path has a Clojure-related extension or Babashka shebang."
+
+     Supported extensions:
+     - .clj (Clojure)
+     - .cljs (ClojureScript)
+     - .cljc (Clojure/ClojureScript shared)
+     - .bb (Babashka)
+     - .edn (Extensible Data Notation)
+     - .lpy (Librepl)
+     Also detects files starting with a Babashka shebang (`bb`)."
+    [file-path]
+    (when file-path
+      (let [lower-path (str/lower-case file-path)]
+        (or (str/ends-with? lower-path ".clj")
+            (str/ends-with? lower-path ".cljs")
+            (str/ends-with? lower-path ".cljc")
+            (str/ends-with? lower-path ".bb")
+            (str/ends-with? lower-path ".lpy")
+            (str/ends-with? lower-path ".edn")
+            (babashka-shebang? file-path)))))
 
 (defn extract-paths-from-bash-command
   "Extract file/directory paths from a bash command string.

--- a/test/clojure_mcp/tools/file_write/core_test.clj
+++ b/test/clojure_mcp/tools/file_write/core_test.clj
@@ -54,7 +54,13 @@
     (is (file-write-core/is-clojure-file? "C:\\Path\\To\\File.CLJ")) ; Case insensitive
     (is (not (file-write-core/is-clojure-file? "test.txt")))
     (is (not (file-write-core/is-clojure-file? "test.md")))
-    (is (not (file-write-core/is-clojure-file? "test.js")))))
+    (is (not (file-write-core/is-clojure-file? "test.js"))))
+
+  (testing "Detecting Babashka shebang"
+    (let [tmp (io/file *test-dir* "script.sh")]
+      (spit tmp "#!/usr/bin/env bb\n(println :hi)")
+      (is (file-write-core/is-clojure-file? (.getPath tmp)))
+      (.delete tmp))))
 
 (deftest write-text-file-test
   (testing "Creating a new text file"

--- a/test/clojure_mcp/tools/unified_read_file/tool_test.clj
+++ b/test/clojure_mcp/tools/unified_read_file/tool_test.clj
@@ -61,6 +61,10 @@
     (is (unified-read-file-tool/collapsible-clojure-file? "test.cljc"))
     (is (unified-read-file-tool/collapsible-clojure-file? "test.bb"))
     (is (unified-read-file-tool/collapsible-clojure-file? "/path/to/file.clj"))
+    (let [tmp (io/file *test-dir* "script.sh")]
+      (spit tmp "#!/usr/bin/env bb\n(println :hi)")
+      (is (unified-read-file-tool/collapsible-clojure-file? (.getPath tmp)))
+      (.delete tmp))
     (is (not (unified-read-file-tool/collapsible-clojure-file? "test.edn"))) ; EDN files not collapsible
     (is (not (unified-read-file-tool/collapsible-clojure-file? "test.txt")))
     (is (not (unified-read-file-tool/collapsible-clojure-file? "test.md")))

--- a/test/clojure_mcp/utils/valid_paths_test.clj
+++ b/test/clojure_mcp/utils/valid_paths_test.clj
@@ -102,6 +102,18 @@
     (is (= ".."
            (valid-paths/preprocess-path "..")))))
 
+(deftest clojure-file?-test
+  (testing "Detect Babashka shebang"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir") "bb-script.sh")]
+      (spit tmp "#!/usr/bin/env bb\n(println :hi)")
+      (is (valid-paths/clojure-file? (.getPath tmp)))
+      (.delete tmp)))
+  (testing "Regular bash script not detected"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir") "bash-script.sh")]
+      (spit tmp "#!/bin/bash\necho hi")
+      (is (not (valid-paths/clojure-file? (.getPath tmp))))
+      (.delete tmp))))
+
 (deftest validate-bash-command-paths-test
   (let [test-dir (.getCanonicalPath (io/file (System/getProperty "java.io.tmpdir")))
         home-dir (System/getProperty "user.home")]


### PR DESCRIPTION
## Summary
- handle Babashka `bb` shebangs in `clojure-file?`
- reuse new detection in file-write and unified-read tools
- cover babashka scripts in unit tests

## Testing
- `clojure -X:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0c1b3724c83308265bb45eee7fe34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clojure file detection now recognizes Babashka shebang scripts, even without Clojure-like extensions.
  - Expanded recognition to include .lpy files.
  - Improved “collapsible” Clojure file detection for unified read, excluding .edn from collapsing.
- Documentation
  - Updated descriptions to reflect shebang-based detection and supported extensions.
- Tests
  - Added tests validating Babashka shebang recognition and ensuring non-Babashka scripts are not treated as Clojure files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->