### PR TITLE
Initial draft of new config docs

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,14 +1,14 @@
 # Clojure-MCP Configuration
 
-While the initial alpha-release of clojure-mcp might have required rolling your own custom
-MCP server, recent releases allow for much more configuration to be done via a configuration file.
+If you want to tweak the operation of clojure-mcp but do not want to customize your own server,
+you can now control most settings via a configuration file.
 
 The default location for the configuration file is `.clojure-mcp/config.edn`. This, of course,
-can be configured as well.
+is also configurable.
 
 ## Core Configuration
 
-These basic settings globally affect how clojure-mcp interacts with your local system.
+These basic settings affect how clojure-mcp interacts with your local system.
 
 #### `:allowed-directories`
 Controls which directories the MCP tools can access for security. Paths can be relative (resolved from project root) or absolute.
@@ -102,24 +102,41 @@ Much of the behavior of clojure-mcp is exposed as components. These include reso
 
 #### Resources
 
+Configured under the `:resources` key.
+
 Resources include files and other content you want to use with clojure-mcp.
-The standard guide for creating resources in MCP. Resources provide read-only content like documentation, configuration files, or project information. This same approach works whether you're using ClojureMCP or creating standalone resources.
+Resources provide read-only content like documentation, configuration files, or project information. This same approach works whether you're using ClojureMCP or creating standalone resources.
 
 [Configuring Resources](doc/configuring-resources.md)
 
 #### Prompts
 
+Configured under the `:prompts` key.
+
 You can add your own prompts to clojure-mcp, then call them as-needed by name.
-The standard guide for creating prompts in MCP. Prompts generate conversation contexts to help AI assistants understand specific tasks or workflows. This same approach works whether you're using ClojureMCP or creating standalone prompts.
+Prompts generate conversation contexts to help AI assistants understand specific tasks or workflows. This same approach works whether you're using ClojureMCP or creating standalone prompts.
 
 [Creating Prompts](doc/creating-prompts.md)
 
 #### Models
 
+Configured under the `:models` key.
+
 You may want to use different models than provided by default.
 Configure custom LLM models with your own API keys, endpoints, and parameters. Support for OpenAI, Anthropic, Google Gemini, and more through the LangChain4j integration.
 
 [Model Configuration](doc/model-configuration.md)
+
+#### Agents
+
+Configured under the `:agents` key.
+
+TBD
+
+#### Tools Configuration
+
+Configured under the `:tools-config` key.
+
 
 #### Component Filtering
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -3,17 +3,17 @@
 If you want to tweak the operation of clojure-mcp but do not want to customize your own server,
 you can now control most settings via a configuration file.
 
-The default location for the configuration file is `.clojure-mcp/config.edn`. This, of course,
-is also configurable.
+The default location for the configuration file is `.clojure-mcp/config.edn`. You can override this path
+via the `:config-file` CLI arg (see README “CLI options”).
 
 ## Core Configuration
 
 These basic settings affect how clojure-mcp interacts with your local system.
 
-#### `:allowed-directories`
+### `:allowed-directories`
 Controls which directories the MCP tools can access for security. Paths can be relative (resolved from project root) or absolute.
 
-#### `:cljfmt`
+### `:cljfmt`
 Boolean flag to enable/disable cljfmt formatting in editing pipelines (default: `true`). When disabled, file edits preserve the original formatting without applying cljfmt.
 
 **Available values:**
@@ -24,7 +24,7 @@ Boolean flag to enable/disable cljfmt formatting in editing pipelines (default: 
 - `true` - Best for maintaining consistent code style across your project
 - `false` - Useful when working with files that have specific formatting requirements or when you want to preserve manual formatting
 
-#### `write-file-guard`
+### `:write-file-guard`
 Controls the file timestamp tracking behavior (default: `:partial-read`). This setting determines when file editing is allowed based on read operations.
 
 **Available values:**
@@ -39,20 +39,20 @@ Controls the file timestamp tracking behavior (default: `:partial-read`). This s
 
 The timestamp tracking system prevents accidental overwrites when files are modified by external processes (other developers, editors, git operations, etc.).
 
-#### `emacs-notify`
+### `:emacs-notify`
 Boolean flag to enable Emacs integration notifications.
 
-Emacs notify is only a toy for now... it switches focuses on the file
-being edited and highlights changes as they are happening.  There are
-probably much better ways to handle this with auto-revert and existing
-emacs libraries.
+Emacs notify is only a toy for now... it switches focus to the file
+being edited and highlights changes as they happen. There are
+probably better ways to handle this with auto-revert and existing
+Emacs libraries.
 
 **Prerequisites for Emacs Integration:**
 - `emacsclient` must be available in your system PATH
 - Emacs server must be running (start with `M-x server-start` or add `(server-start)` to your init file)
 - The integration allows the MCP server to communicate with your Emacs editor for enhanced development workflows
 
-#### `scratch-pad-load`
+### `:scratch-pad-load`
 Boolean flag to automatically load the scratch pad on startup (default: `false`).
 
 **Available values:**
@@ -63,13 +63,13 @@ Boolean flag to automatically load the scratch pad on startup (default: `false`)
 - `false` - Best for temporary planning and session-only data
 - `true` - When you want data to persist across sessions and server restarts
 
-#### `scratch-pad-file`
+### `:scratch-pad-file`
 Filename for scratch pad persistence (default: `"scratch_pad.edn"`).
 
 **Configuration:**
 - Specifies the filename within `.clojure-mcp/` directory
 
-#### `:bash-over-nrepl`
+### `:bash-over-nrepl`
 Boolean flag to control bash command execution mode (default: `true`). This setting determines whether bash commands are executed over the nREPL connection or locally on the MCP server.
 
 **Available values:**
@@ -77,15 +77,15 @@ Boolean flag to control bash command execution mode (default: `true`). This sett
 - `false` - Execute bash commands locally in the Clojure MCP server process
 
 **When to use each setting:**
-- `true` - Best for most development scenarios, as it allows you to only sandbox the nrepl server process
-- `false` - Useful when the nREPL server is not a Clojure process, i.e. CLJS, Babashka, Scittle
+- `true` - Best for most development scenarios, as it allows you to sandbox only the nREPL server process
+- `false` - Useful when the nREPL server is not a Clojure process (e.g., ClojureScript/CLJS, Babashka, Scittle)
 
 **Technical details:**
 - When `true`, bash commands run in a separate nREPL session
 - Both modes apply consistent output truncation (8500 chars total, split between stdout/stderr)
 - Local execution may be faster for simple commands but requires the MCP server to have necessary tools installed
 
-#### `dispatch-agent-context`
+### `:dispatch-agent-context`
 Primes the dispatch agent with details about your code to help it find answers more quickly and accurately.
 
 **Available values:**
@@ -100,7 +100,7 @@ Additional options allow you to fine-tune, augment, and even override default be
 
 Much of the behavior of clojure-mcp is exposed as components. These include resources, prompts, agents, tools, and models.
 
-#### Resources
+### Resources
 
 Configured under the `:resources` key.
 
@@ -109,7 +109,7 @@ Resources provide read-only content like documentation, configuration files, or 
 
 [Configuring Resources](doc/configuring-resources.md)
 
-#### Prompts
+### Prompts
 
 Configured under the `:prompts` key.
 
@@ -118,7 +118,7 @@ Prompts generate conversation contexts to help AI assistants understand specific
 
 [Creating Prompts](doc/creating-prompts.md)
 
-#### Models
+### Models
 
 Configured under the `:models` key.
 
@@ -127,18 +127,18 @@ Configure custom LLM models with your own API keys, endpoints, and parameters. S
 
 [Model Configuration](doc/model-configuration.md)
 
-#### Agents
+### Agents
 
 Configured under the `:agents` key.
 
-TBD
+See Agent configuration guidance in the README’s “Agent Tools” section; dedicated docs forthcoming.
 
-#### Tools Configuration
+### Tools Configuration
 
 Configured under the `:tools-config` key.
 
 
-#### Component Filtering
+### Component Filtering
 
 For each server you have defined, you have granular control over the tools, prompts, and resources exposed by using filters.
 Learn how to control which tools, prompts, and resources are exposed by your MCP server using enable/disable lists. Perfect for creating focused, secure, or specialized MCP servers with only the components you need.
@@ -147,4 +147,4 @@ Learn how to control which tools, prompts, and resources are exposed by your MCP
 
 ### Advanced Customization
 
-See 'custom server' docs
+See the Custom MCP Server guide: `doc/custom-mcp-server.md`

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,133 @@
+# Clojure-MCP Configuration
+
+While the initial alpha-release of clojure-mcp might have required rolling your own custom
+MCP server, recent releases allow for much more configuration to be done via a configuration file.
+
+The default location for the configuration file is `.clojure-mcp/config.edn`. This, of course,
+can be configured as well.
+
+## Core Configuration
+
+These basic settings globally affect how clojure-mcp interacts with your local system.
+
+#### `:allowed-directories`
+Controls which directories the MCP tools can access for security. Paths can be relative (resolved from project root) or absolute.
+
+#### `:cljfmt`
+Boolean flag to enable/disable cljfmt formatting in editing pipelines (default: `true`). When disabled, file edits preserve the original formatting without applying cljfmt.
+
+**Available values:**
+- `true` (default) - Applies cljfmt formatting to all edited files
+- `false` - Disables formatting, preserving exact whitespace and formatting
+
+**When to use each setting:**
+- `true` - Best for maintaining consistent code style across your project
+- `false` - Useful when working with files that have specific formatting requirements or when you want to preserve manual formatting
+
+#### `write-file-guard`
+Controls the file timestamp tracking behavior (default: `:partial-read`). This setting determines when file editing is allowed based on read operations.
+
+**Available values:**
+- `:partial-read` (default) - Both full and collapsed reads update timestamps. Allows editing after collapsed reads, providing more convenience with slightly less safety.
+- `:full-read` - Only full reads (`collapsed: false`) update timestamps. This is the safest option, ensuring the AI sees complete file content before editing.
+- `false` - Disables timestamp checking entirely. Files can be edited without any read requirement. Use with caution!
+
+**When to use each setting:**
+- `:partial-read` - Good for solo development when you want faster workflows but still want protection against external modifications
+- `:full-read` - Best for team environments or when working with files that may be modified externally
+- `false` - Only for rapid prototyping or when you're certain no external modifications will occur
+
+The timestamp tracking system prevents accidental overwrites when files are modified by external processes (other developers, editors, git operations, etc.).
+
+#### `emacs-notify`
+Boolean flag to enable Emacs integration notifications.
+
+Emacs notify is only a toy for now... it switches focuses on the file
+being edited and highlights changes as they are happening.  There are
+probably much better ways to handle this with auto-revert and existing
+emacs libraries.
+
+**Prerequisites for Emacs Integration:**
+- `emacsclient` must be available in your system PATH
+- Emacs server must be running (start with `M-x server-start` or add `(server-start)` to your init file)
+- The integration allows the MCP server to communicate with your Emacs editor for enhanced development workflows
+
+#### `scratch-pad-load`
+Boolean flag to automatically load the scratch pad on startup (default: `false`).
+
+**Available values:**
+- `false` (default) - Scratch pad is saved to disk but not loaded on startup
+- `true` - Loads existing data on startup
+
+**When to use each setting:**
+- `false` - Best for temporary planning and session-only data
+- `true` - When you want data to persist across sessions and server restarts
+
+#### `scratch-pad-file`
+Filename for scratch pad persistence (default: `"scratch_pad.edn"`).
+
+**Configuration:**
+- Specifies the filename within `.clojure-mcp/` directory
+
+#### `:bash-over-nrepl`
+Boolean flag to control bash command execution mode (default: `true`). This setting determines whether bash commands are executed over the nREPL connection or locally on the MCP server.
+
+**Available values:**
+- `true` (default) - Execute bash commands over nREPL connection with isolated session
+- `false` - Execute bash commands locally in the Clojure MCP server process
+
+**When to use each setting:**
+- `true` - Best for most development scenarios, as it allows you to only sandbox the nrepl server process
+- `false` - Useful when the nREPL server is not a Clojure process, i.e. CLJS, Babashka, Scittle
+
+**Technical details:**
+- When `true`, bash commands run in a separate nREPL session
+- Both modes apply consistent output truncation (8500 chars total, split between stdout/stderr)
+- Local execution may be faster for simple commands but requires the MCP server to have necessary tools installed
+
+#### `dispatch-agent-context`
+Primes the dispatch agent with details about your code to help it find answers more quickly and accurately.
+
+**Available values:**
+- `true` (default) - Adds `PROJECT_SUMMARY.md` (if available) and `./.clojure-mcp/code_index.txt` into context
+- Specifies a vector of specific files sent to `dispatch_agent`
+
+NOTE: May consume more API tokens or even exceed the context window of the LLM
+
+### Intermediate-Level Customization
+
+Additional options allow you to fine-tune, augment, and even override default behavior.
+
+Much of the behavior of clojure-mcp is exposed as components. These include resources, prompts, agents, tools, and models.
+
+#### Resources
+
+Resources include files and other content you want to use with clojure-mcp.
+The standard guide for creating resources in MCP. Resources provide read-only content like documentation, configuration files, or project information. This same approach works whether you're using ClojureMCP or creating standalone resources.
+
+[Configuring Resources](doc/configuring-resources.md)
+
+#### Prompts
+
+You can add your own prompts to clojure-mcp, then call them as-needed by name.
+The standard guide for creating prompts in MCP. Prompts generate conversation contexts to help AI assistants understand specific tasks or workflows. This same approach works whether you're using ClojureMCP or creating standalone prompts.
+
+[Creating Prompts](doc/creating-prompts.md)
+
+#### Models
+
+You may want to use different models than provided by default.
+Configure custom LLM models with your own API keys, endpoints, and parameters. Support for OpenAI, Anthropic, Google Gemini, and more through the LangChain4j integration.
+
+[Model Configuration](doc/model-configuration.md)
+
+#### Component Filtering
+
+For each server you have defined, you have granular control over the tools, prompts, and resources exposed by using filters.
+Learn how to control which tools, prompts, and resources are exposed by your MCP server using enable/disable lists. Perfect for creating focused, secure, or specialized MCP servers with only the components you need.
+
+[Component Filtering Configuration](doc/component-filtering.md)
+
+### Advanced Customization
+
+See 'custom server' docs

--- a/README.md
+++ b/README.md
@@ -805,7 +805,7 @@ Personally I `source` them right in bash command:
 }
 ```
 
-> **Note**: The agent tools will work with any available API key. You don't need all three - just set up the ones you have access to. The tools will automatically select from available models. For now the ANTHROPIC API is limited to the displatch_agent.
+> **Note**: The agent tools will work with any available API key. You don't need all three - just set up the ones you have access to. The tools will automatically select from available models. For now the ANTHROPIC API is limited to the dispatch_agent.
 
 
 ## Learning Curve
@@ -1016,7 +1016,7 @@ Boolean flag to enable/disable cljfmt formatting in editing pipelines (default: 
 - `true` - Best for maintaining consistent code style across your project
 - `false` - Useful when working with files that have specific formatting requirements or when you want to preserve manual formatting
 
-#### `bash-over-nrepl`
+#### `:bash-over-nrepl`
 Boolean flag to control bash command execution mode (default: `true`). This setting determines whether bash commands are executed over the nREPL connection or locally on the MCP server.
 
 **Available values:**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive CONFIG.md describing a centralized .clojure-mcp/config.edn, defaults, core options (allowed directories, cljfmt toggle, write-file-guard modes, emacs notifications, scratch pad, bash-over-nrepl, dispatch-agent-context), intermediate component configuration/filtering, advanced customization pointers, and notes on token/context impacts.
  * Updated README: fixed typos, standardized formatting, renamed option styling, and expanded bash-over-nrepl technical details including output truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->