### PR TITLE
Fixes #109 - Make pattern matching stricter when parsing for port

### DIFF
--- a/src/clojure_mcp/nrepl_launcher.clj
+++ b/src/clojure_mcp/nrepl_launcher.clj
@@ -15,8 +15,8 @@
    Returns the port number as an integer or nil if not found."
   [output]
   (when output
-    (let [patterns [#"nREPL server started on port[^\d]*(\d+)" ; nREPL server started on port 12345
-                    #_#"(?i)port[^\d]*(\d+)" ; port 12345, port: 12345
+    (let [patterns [#"nREPL server started on port\s{1,10}(\d+)" ; nREPL server started on port 12345
+                    ;; remaining patterns unchanged
                     #":(\d{4,5})\b" ; :12345 (4-5 digit ports)
                     #"Started.*?(\d{4,5})\b" ; Started on 12345
                     #"Listening.*?(\d{4,5})\b"] ; Listening on 12345

--- a/src/clojure_mcp/nrepl_launcher.clj
+++ b/src/clojure_mcp/nrepl_launcher.clj
@@ -16,7 +16,7 @@
   [output]
   (when output
     (let [patterns [#"nREPL server started on port[^\d]*(\d+)" ; nREPL server started on port 12345
-                    #"(?i)port[^\d]*(\d+)" ; port 12345, port: 12345
+                    #_#"(?i)port[^\d]*(\d+)" ; port 12345, port: 12345
                     #":(\d{4,5})\b" ; :12345 (4-5 digit ports)
                     #"Started.*?(\d{4,5})\b" ; Started on 12345
                     #"Listening.*?(\d{4,5})\b"] ; Listening on 12345

--- a/src/clojure_mcp/nrepl_launcher.clj
+++ b/src/clojure_mcp/nrepl_launcher.clj
@@ -15,7 +15,7 @@
    Returns the port number as an integer or nil if not found."
   [output]
   (when output
-    (let [patterns [#"(?i)nrepl.*?port[^\d]*(\d+)" ; nREPL server started on port 12345
+    (let [patterns [#"nREPL server started on port[^\d]*(\d+)" ; nREPL server started on port 12345
                     #"(?i)port[^\d]*(\d+)" ; port 12345, port: 12345
                     #":(\d{4,5})\b" ; :12345 (4-5 digit ports)
                     #"Started.*?(\d{4,5})\b" ; Started on 12345


### PR DESCRIPTION
See #109 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved nREPL port detection by prioritizing explicit server startup messages, reducing false positives when auto-connecting.
  - Continued support for several common log formats to ensure ports are still discovered in typical setups.
  - Narrower matching rules may change behavior for some rare or custom log outputs but increase overall connection reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->