### PR TITLE
Improve port parsing patterns to prevent FlowStorm false positives

### DIFF
--- a/src/clojure_mcp/nrepl_launcher.clj
+++ b/src/clojure_mcp/nrepl_launcher.clj
@@ -15,11 +15,10 @@
    Returns the port number as an integer or nil if not found."
   [output]
   (when output
-    (let [patterns [#"(?i)nrepl.*?port[^\d]*(\d+)" ; nREPL server started on port 12345
-                    #"(?i)port[^\d]*(\d+)" ; port 12345, port: 12345
-                    #":(\d{4,5})\b" ; :12345 (4-5 digit ports)
-                    #"Started.*?(\d{4,5})\b" ; Started on 12345
-                    #"Listening.*?(\d{4,5})\b"] ; Listening on 12345
+    (let [patterns [#"(?i)port\s{1,10}(\d+)\b" ; port 12345
+                    #":\s?(\d{4,5})\b" ; :12345 or : 12345 (4-5 digit ports)
+                    #"(?i)Started on\s{1,10}(\d{4,5})\b" ; Started on 12345
+                    #"(?i)Listening on\s{1,10}(\d{4,5})\b"] ; Listening on 12345
           line (str/trim output)]
       (some (fn [pattern]
               (when-let [match (re-find pattern line)]

--- a/src/clojure_mcp/nrepl_launcher.clj
+++ b/src/clojure_mcp/nrepl_launcher.clj
@@ -15,7 +15,7 @@
    Returns the port number as an integer or nil if not found."
   [output]
   (when output
-    (let [patterns [#"(?i)port\s{1,10}(\d+)\b" ; port 12345
+    (let [patterns [#"(?i)\bport\s{1,10}(\d{4,5})\b" ; port 12345
                     #":\s?(\d{4,5})\b" ; :12345 or : 12345 (4-5 digit ports)
                     #"(?i)Started on\s{1,10}(\d{4,5})\b" ; Started on 12345
                     #"(?i)Listening on\s{1,10}(\d{4,5})\b"] ; Listening on 12345

--- a/test/clojure_mcp/nrepl_launcher_test.clj
+++ b/test/clojure_mcp/nrepl_launcher_test.clj
@@ -26,7 +26,9 @@
         "port abc" ; non-numeric
         "port 123" ; too small (below 1024)
         "port 999999" ; too large (above 65535)
-        "random text"))
+        "random text"
+        ;; FlowStorm output should not match (issue #109)
+        "flow_storm.jobs$run_jobs$mem_reporter__4628@348137e8 function scheduled every 1000 millis"))
 
     (testing "handles case insensitive matching"
       (are [output expected] (= expected (launcher/parse-port-from-output output))


### PR DESCRIPTION
This PR improves upon PR #110 by refining the port parsing regex patterns to be both stricter (preventing false positives) and more flexible (supporting case-insensitive matching).

## Changes

- Add case-insensitive matching to port, Started, and Listening patterns using `(?i)`
- Use bounded whitespace `\s{1,10}` instead of unbounded `\s+` or `.*?` for predictability
- Add optional space after colon in port number pattern `:\s?`
- Add word boundary `\b` to port pattern to prevent false matches
- Add regression test for FlowStorm output to ensure it doesn't match

## Fixes #109

The original issue reported that FlowStorm's output:
```
flow_storm.jobs$run_jobs$mem_reporter__4628@348137e8 function scheduled every 1000 millis
```

Was incorrectly matching the old regex pattern and extracting `4628` as the port number.

## Final Regex Patterns

```clojure
#"(?i)port\s{1,10}(\d+)\b"              ; Matches: "port 12345", "PORT 12345"
#":\s?(\d{4,5})\b"                      ; Matches: ":12345", ": 12345"
#"(?i)Started on\s{1,10}(\d{4,5})\b"    ; Matches: "Started on 12345"
#"(?i)Listening on\s{1,10}(\d{4,5})\b"  ; Matches: "Listening on 12345"
```

## What These Patterns Don't Match

- ❌ `flow_storm.jobs$run_jobs$mem_reporter__4628@348137e8...` (the original issue)
- ❌ `Started batch job 45000`
- ❌ `Listening to 30000 events`

These patterns are stricter than the original code while maintaining backward compatibility with all existing test cases.

Co-authored-by: gveres <gveres@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Streamlined port-detection logic to reduce false positives and improve accuracy across varied startup logs; behavior unchanged for valid outputs.
  - Now explicitly ignores FlowStorm-style messages to avoid reporting incorrect ports.

- Tests
  - Added a negative test for FlowStorm output and expanded parsing/range checks to improve reliability and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->