### PR TITLE
Add clojure_edit_agent for structural code editing

### DIFF
--- a/resources/clojure-mcp/agents/clojure_edit_agent.edn
+++ b/resources/clojure-mcp/agents/clojure_edit_agent.edn
@@ -1,0 +1,64 @@
+{:id :clojure-edit-agent
+ :name "clojure_edit_agent"
+ :description "Specialized Clojure code editor that applies code changes to a single file using structural editing tools.
+
+To use this agent, provide:
+1. The absolute path to the file
+2. Instructions describing what needs to be changed
+3. Code snippets showing the desired changes
+
+Format:
+```
+target_file: /absolute/path/to/file.clj
+instructions: Brief description of what needs to be changed
+
+;; ... existing code before the change ...
+(defn function-to-modify [args]
+  ;; New implementation here
+  ...)
+;; ... existing code after the change ...
+```
+
+IMPORTANT FORMAT RULES:
+- Use `;; ... existing code ...` or similar markers to represent unchanged code sections
+- Include sufficient context around changes to unambiguously locate the code to modify
+- Minimize repeating unchanged code - only show what's needed for context
+- Never omit code sections without using the `;; ...` marker
+- No line numbers needed - the context helps locate the changes
+- You can include multiple changes within the single file
+
+Example:
+```
+target_file: /path/to/math.clj
+instructions: Add validation to calculate function and make add handle nil values
+
+;; ... namespace and imports ...
+
+(defn calculate [x y operation]
+  ;; Add input validation
+  (when (or (nil? x) (nil? y))
+    (throw (IllegalArgumentException. \"Inputs cannot be nil\")))
+  (operation x y))
+
+;; ... other functions ...
+
+(defn add [a b]
+  ;; Handle nil by treating as 0
+  (+ (or a 0) (or b 0)))
+
+;; ... rest of file ...
+```
+
+The agent will read the file, identify the locations to change based on context, apply the changes using clojure_edit tools, and return a summary with diffs showing all modifications."
+ :system-message "You are an efficient Clojure code editor that works on a single file at a time. When provided with a file path and edit instructions:
+
+1. Read the target file to understand its current state
+2. Identify the exact locations that need to be changed based on the context provided
+3. Use the appropriate clojure_edit tools (clojure_edit for defn/def replacements, clojure_edit_replace_sexp for expression changes) to make the changes
+4. Apply all requested changes efficiently
+5. The file change tracking system will automatically show diffs of your modifications
+
+Remember: Prefer structural editing tools over text-based editing for reliability and to maintain proper Clojure syntax."
+ :context false
+ :enable-tools [:read_file :clojure_edit :clojure_edit_replace_sexp :glob_files :grep :file_edit]
+ :track-file-changes true}

--- a/src/clojure_mcp/tools/agent_tool_builder/default_agents.clj
+++ b/src/clojure_mcp/tools/agent_tool_builder/default_agents.clj
@@ -1,7 +1,8 @@
 (ns clojure-mcp.tools.agent-tool-builder.default-agents
   "Default agent configurations that replicate the functionality of
    the original hardcoded agent tools (dispatch_agent, architect, code_critique)"
-  (:require [clojure.java.io :as io]))
+  (:require [clojure.java.io :as io]
+            [clojure.edn :as edn]))
 
 (defn dispatch-agent-config
   "Configuration for the dispatch agent - a general purpose agent with read-only tools"
@@ -36,6 +37,13 @@
    :enable-tools nil ; No tools needed
    :memory-size 35})
 
+(defn clojure-edit-agent-config
+  "Configuration for the clojure edit agent - loaded from EDN resource"
+  []
+  (-> (io/resource "clojure-mcp/agents/clojure_edit_agent.edn")
+      slurp
+      edn/read-string))
+
 (defn parent-agent-config
   "Configuration for the parent agent - has all tools and uses Clojure REPL system prompt"
   []
@@ -54,12 +62,13 @@
   []
   [(dispatch-agent-config)
    (architect-config)
-   (code-critique-config)])
+   (code-critique-config)
+   (clojure-edit-agent-config)])
 
 (defn default-agent-ids
   "Returns a set of default agent IDs for easy checking"
   []
-  #{:dispatch-agent :architect :code-critique})
+  #{:dispatch-agent :architect :code-critique :clojure-edit-agent})
 
 (defn merge-tool-config-into-agent
   "Merges tool-specific configuration from :tools-config into an agent configuration.

--- a/src/clojure_mcp/tools/agent_tool_builder/tool.clj
+++ b/src/clojure_mcp/tools/agent_tool_builder/tool.clj
@@ -88,7 +88,8 @@
         ;; Map tool-id keywords to agent-id keywords
         tool-id->agent-id {:dispatch_agent :dispatch-agent
                            :architect :architect
-                           :code_critique :code-critique}
+                           :code_critique :code-critique
+                           :clojure_edit_agent :clojure-edit-agent}
 
         ;; Merge tool configs into matching default agents
         default-agents-with-tool-config

--- a/test/clojure_mcp/tools/agent_tool_builder/tool_test.clj
+++ b/test/clojure_mcp/tools/agent_tool_builder/tool_test.clj
@@ -41,8 +41,8 @@
 (deftest test-create-agent-tools
   (testing "Default agents are always created even with empty config"
     (let [nrepl-atom (atom {::config/config {:agents []}})]
-      ;; Should create the 3 default agents (dispatch_agent, architect, code_critique)
-      (is (= 3 (count (agent-builder/create-agent-tools nrepl-atom))))))
+      ;; Should create the 4 default agents (dispatch_agent, architect, code_critique, clojure_edit_agent)
+      (is (= 4 (count (agent-builder/create-agent-tools nrepl-atom))))))
 
   (testing "Creates tools for configured agents plus defaults"
     (let [agent-config {:id :test-agent
@@ -55,12 +55,13 @@
           nrepl-atom (atom {::config/config {:agents [agent-config]}})
           tools (agent-builder/create-agent-tools nrepl-atom)
           tool-names (map :name tools)]
-      ;; Should have 3 defaults + 1 user agent
-      (is (= 4 (count tools)))
+      ;; Should have 4 defaults + 1 user agent
+      (is (= 5 (count tools)))
       (is (some #{"test_agent"} tool-names))
       (is (some #{"dispatch_agent"} tool-names))
       (is (some #{"architect"} tool-names))
-      (is (some #{"code_critique"} tool-names)))))
+      (is (some #{"code_critique"} tool-names))
+      (is (some #{"clojure_edit_agent"} tool-names)))))
 
 (deftest test-agent-config-retrieval
   (testing "Get agents config"
@@ -177,13 +178,14 @@
           agents (agent-builder/create-agent-tools test-atom)
           agent-names (map :name agents)]
 
-      ;; Should have 3 default agents
-      (is (= (count agents) 3))
+      ;; Should have 4 default agents
+      (is (= (count agents) 4))
 
       ;; Check that all default agents are present
       (is (some #{"dispatch_agent"} agent-names))
       (is (some #{"architect"} agent-names))
-      (is (some #{"code_critique"} agent-names)))))
+      (is (some #{"code_critique"} agent-names))
+      (is (some #{"clojure_edit_agent"} agent-names)))))
 
 (deftest test-user-agents-override-defaults
   (testing "User-defined agents override default agents with same ID"
@@ -200,8 +202,8 @@
           agents (agent-builder/create-agent-tools test-atom)
           agent-names (map :name agents)]
 
-      ;; Should still have 3 agents total (2 defaults + 1 custom replacing dispatch-agent)
-      (is (= (count agents) 3))
+      ;; Should still have 4 agents total (3 defaults + 1 custom replacing dispatch-agent)
+      (is (= (count agents) 4))
 
       ;; Check that the custom agent replaced the default
       (is (some #{"custom_dispatch"} agent-names))


### PR DESCRIPTION
## Summary
- Restore the clojure-edit-agent that was previously removed (commit 315f31c)
- Specializes in applying code changes to a single Clojure file using structural editing tools
- Includes file discovery tools (glob, grep) in case provided paths are incorrect

## Tools enabled
- `read_file` - read target file
- `clojure_edit` - structural defn/def replacements
- `clojure_edit_replace_sexp` - structural expression changes
- `glob_files` - find files by pattern
- `grep` - search for code patterns
- `file_edit` - fallback text-based editing

## Test plan
- [x] All tests pass (275 tests, 1993 assertions)
- [x] Linter passes
- [ ] Manual test with prompt-cli:
  ```bash
  clojure -M:prompt-cli -c resources/clojure-mcp/agents/clojure_edit_agent.edn     -p "Add docstring to function foo in /path/to/file.clj"
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new Clojure code-editing agent available by default. This agent enables users to perform structured edits on Clojure files with support for file operations, edit application, and automatic diff generation for review.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->