### PR TITLE
Add :config-profile CLI option for resource-based config overlays

### DIFF
--- a/resources/clojure_mcp/configs/cli-assist.edn
+++ b/resources/clojure_mcp/configs/cli-assist.edn
@@ -1,0 +1,6 @@
+{:enable-tools
+ [:clojure_edit_agent
+  :list_nrepl_ports
+  :clojure_eval]
+
+ :write-file-guard false}

--- a/src/clojure_mcp/config.clj
+++ b/src/clojure_mcp/config.clj
@@ -41,7 +41,7 @@
   (let [home-config-file (get-home-config-path)]
     (load-config-file (.getPath home-config-file))))
 
-(defn- deep-merge
+(defn deep-merge
   "Deeply merges maps, with the second map taking precedence.
    For non-map values, the second value wins."
   [m1 m2]
@@ -50,6 +50,46 @@
     (merge-with deep-merge m1 m2)
 
     :else m2))
+
+(defn load-config-profile
+  "Loads a config profile from classpath resources.
+
+   Profile is loaded from: clojure_mcp/configs/<profile-name>.edn
+
+   Input: profile - keyword, symbol, or string identifying the profile
+   Output: parsed EDN map, or {} if not found or failed to parse
+
+   Logs a warning if the profile resource is not found or fails to parse."
+  [profile]
+  (when profile
+    (let [profile-name (name profile)
+          resource-path (str "clojure_mcp/configs/" profile-name ".edn")]
+      (if-let [resource (io/resource resource-path)]
+        (try
+          (edn/read-string (slurp resource))
+          (catch Exception e
+            (log/warn e "Failed to parse config profile:" profile-name)
+            {}))
+        (do
+          (log/warn "Config profile not found:" profile-name
+                    "(expected at" resource-path ")")
+          {})))))
+
+(defn apply-config-profile
+  "Applies a config profile overlay to a base config.
+
+   The profile is deep-merged on top of the base config, so profile values win.
+
+   Input:
+   - config: base configuration map
+   - profile: keyword, symbol, or string identifying the profile (or nil)
+
+   Output: config with profile merged in (or unchanged config if profile is nil)"
+  [config profile]
+  (if profile
+    (let [profile-config (load-config-profile profile)]
+      (deep-merge config profile-config))
+    config))
 
 (defn- merge-configs
   "Merges user home config (defaults) with project config (overrides).
@@ -111,49 +151,69 @@
       (assoc :nrepl-env-type (:nrepl-env-type config)))))
 
 (defn load-config
-  "Loads the configuration from user home and project directories."
-  [cli-config-file user-dir]
-  ;; Load user home config first (provides defaults)
-  (let [home-config (load-home-config)
-        home-config-path (get-home-config-path)
+  "Loads the configuration from user home and project directories.
 
-        ;; Load project config (provides overrides)
-        project-config-file (if cli-config-file
-                              (io/file cli-config-file)
-                              (io/file user-dir ".clojure-mcp" "config.edn"))
-        project-config (load-config-file (.getPath project-config-file))
+   Optionally applies a config profile overlay from classpath resources.
+   The profile is merged LAST, so profile values have highest precedence.
 
-        ;; Validate configs BEFORE merging
-        ;; This ensures we know which file has the error
-        ;; Use canonical paths for consistent error reporting
-        _ (validate-configs
-           (cond-> []
-             ;; Only validate home config if it exists and has content
-             (seq home-config)
-             (conj {:config home-config
-                    :file-path (.getCanonicalPath home-config-path)})
+   Merge precedence (highest to lowest):
+   1. config-profile overlay (if provided)
+   2. project config (from cli-config-file or .clojure-mcp/config.edn)
+   3. home config (~/.clojure-mcp/config.edn)
 
-             ;; Only validate project config if it exists and has content  
-             (seq project-config)
-             (conj {:config project-config
-                    :file-path (.getCanonicalPath project-config-file)})))
+   Parameters:
+   - cli-config-file: path to project config file (or nil for default)
+   - user-dir: project directory path
+   - config-profile: keyword/symbol/string profile name (optional)"
+  ([cli-config-file user-dir]
+   (load-config cli-config-file user-dir nil))
+  ([cli-config-file user-dir config-profile]
+   ;; Load user home config first (provides defaults)
+   (let [home-config (load-home-config)
+         home-config-path (get-home-config-path)
 
-        ;; Merge configs (project overrides home)
-        merged-config (merge-configs home-config project-config)
+         ;; Load project config (provides overrides)
+         project-config-file (if cli-config-file
+                               (io/file cli-config-file)
+                               (io/file user-dir ".clojure-mcp" "config.edn"))
+         project-config (load-config-file (.getPath project-config-file))
 
-        ;; Process the merged config
-        processed-config (process-config merged-config user-dir)]
+         ;; Validate configs BEFORE merging
+         ;; This ensures we know which file has the error
+         ;; Use canonical paths for consistent error reporting
+         _ (validate-configs
+            (cond-> []
+              ;; Only validate home config if it exists and has content
+              (seq home-config)
+              (conj {:config home-config
+                     :file-path (.getCanonicalPath home-config-path)})
 
-    ;; Logging for debugging
-    (log/debug "Home config file:" (.getCanonicalPath home-config-path) "exists:" (.exists home-config-path))
-    (when (seq home-config)
-      (log/debug "Home config validated successfully"))
-    (log/debug "Project config file:" (.getCanonicalPath project-config-file) "exists:" (.exists project-config-file))
-    (when (seq project-config)
-      (log/debug "Project config validated successfully"))
-    (log/debug "Final processed config:" processed-config)
+              ;; Only validate project config if it exists and has content
+              (seq project-config)
+              (conj {:config project-config
+                     :file-path (.getCanonicalPath project-config-file)})))
 
-    processed-config))
+         ;; Merge configs (project overrides home)
+         merged-config (merge-configs home-config project-config)
+
+         ;; Apply config profile overlay (profile overrides everything)
+         merged-with-profile (apply-config-profile merged-config config-profile)
+
+         ;; Process the merged config
+         processed-config (process-config merged-with-profile user-dir)]
+
+     ;; Logging for debugging
+     (log/debug "Home config file:" (.getCanonicalPath home-config-path) "exists:" (.exists home-config-path))
+     (when (seq home-config)
+       (log/debug "Home config validated successfully"))
+     (log/debug "Project config file:" (.getCanonicalPath project-config-file) "exists:" (.exists project-config-file))
+     (when (seq project-config)
+       (log/debug "Project config validated successfully"))
+     (when config-profile
+       (log/debug "Applied config profile:" config-profile))
+     (log/debug "Final processed config:" processed-config)
+
+     processed-config)))
 
 (defn get-config [nrepl-client-map k]
   (get-in nrepl-client-map [::config k]))

--- a/test/clojure_mcp/config/profile_test.clj
+++ b/test/clojure_mcp/config/profile_test.clj
@@ -1,0 +1,85 @@
+(ns clojure-mcp.config.profile-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure-mcp.config :as config]))
+
+;; Tests for config profile loading functionality
+
+(deftest test-load-config-profile
+  (testing "Loading existing profile returns parsed EDN map"
+    (let [profile-config (config/load-config-profile :cli-assist)]
+      (is (map? profile-config))
+      (is (contains? profile-config :enable-tools))
+      (is (contains? profile-config :write-file-guard))
+      (is (false? (:write-file-guard profile-config)))))
+
+  (testing "Profile can be loaded with keyword"
+    (let [profile-config (config/load-config-profile :cli-assist)]
+      (is (map? profile-config))
+      (is (seq profile-config))))
+
+  (testing "Profile can be loaded with string"
+    (let [profile-config (config/load-config-profile "cli-assist")]
+      (is (map? profile-config))
+      (is (seq profile-config))))
+
+  (testing "Profile can be loaded with symbol"
+    (let [profile-config (config/load-config-profile 'cli-assist)]
+      (is (map? profile-config))
+      (is (seq profile-config))))
+
+  (testing "Missing profile returns empty map"
+    (let [profile-config (config/load-config-profile :nonexistent-profile)]
+      (is (= {} profile-config))))
+
+  (testing "nil profile returns nil"
+    (let [profile-config (config/load-config-profile nil)]
+      (is (nil? profile-config)))))
+
+(deftest test-apply-config-profile
+  (testing "Applying profile merges on top of base config"
+    (let [base-config {:write-file-guard :full-read
+                       :cljfmt true
+                       :some-other-setting "value"}
+          result (config/apply-config-profile base-config :cli-assist)]
+      ;; Profile values should override base
+      (is (false? (:write-file-guard result)))
+      ;; Non-overlapping base values should be preserved
+      (is (true? (:cljfmt result)))
+      (is (= "value" (:some-other-setting result)))
+      ;; Profile values should be present
+      (is (vector? (:enable-tools result)))))
+
+  (testing "Applying nil profile returns config unchanged"
+    (let [base-config {:write-file-guard :partial-read
+                       :cljfmt true}
+          result (config/apply-config-profile base-config nil)]
+      (is (= base-config result))))
+
+  (testing "Applying missing profile returns config unchanged"
+    (let [base-config {:write-file-guard :partial-read
+                       :cljfmt true}
+          result (config/apply-config-profile base-config :nonexistent-profile)]
+      (is (= base-config result))))
+
+  (testing "Deep merge works for nested maps"
+    (let [base-config {:tools-config {:bash {:timeout 5000}
+                                      :grep {:max-results 100}}}
+          ;; Create a temporary profile-like config to test deep merge
+          profile-config {:tools-config {:bash {:enabled false}}}
+          result (config/deep-merge base-config profile-config)]
+      ;; Nested values should be merged, not replaced
+      (is (= 5000 (get-in result [:tools-config :bash :timeout])))
+      (is (false? (get-in result [:tools-config :bash :enabled])))
+      (is (= 100 (get-in result [:tools-config :grep :max-results]))))))
+
+(deftest test-cli-assist-profile-contents
+  (testing "cli-assist profile has expected tools"
+    (let [profile-config (config/load-config-profile :cli-assist)
+          enable-tools (:enable-tools profile-config)]
+      (is (some #{:clojure_edit_agent} enable-tools))
+      (is (some #{:list_nrepl_ports} enable-tools))
+      (is (some #{:clojure_eval} enable-tools))))
+
+  (testing "cli-assist profile disables write-file-guard"
+    (let [profile-config (config/load-config-profile :cli-assist)]
+      (is (false? (:write-file-guard profile-config))))))


### PR DESCRIPTION
## Summary

- Add `:config-profile` CLI option to load built-in config profiles from classpath resources
- Profiles are deep-merged on top of base config with highest precedence
- Include `cli-assist` profile with `clojure_edit_agent`, `list_nrepl_ports`, `clojure_eval` tools enabled and `write-file-guard` disabled

## Usage

```bash
# Apply cli-assist profile
clojure -X:mcp :config-profile :cli-assist

# Combine with custom config file
clojure -X:mcp :config-file '"/tmp/custom.edn"' :config-profile :cli-assist
```

## Merge precedence (highest to lowest)

1. `:config-profile` overlay (if provided)
2. `:config-file` or project config (`.clojure-mcp/config.edn`)
3. home config (`~/.clojure-mcp/config.edn`)

## Test plan

- [x] Unit tests for `load-config-profile` (keyword/string/symbol, missing profile, nil)
- [x] Unit tests for `apply-config-profile` (merge behavior, nil profile, deep merge)
- [x] Unit tests for `cli-assist` profile contents
- [x] All existing tests pass (281 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--config-profile` CLI option to apply predefined configuration profiles that customize tooling behavior
  * Configuration profiles overlay settings on top of base configuration for flexible customization

* **Tests**
  * Added comprehensive test coverage for profile loading and merging functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->