### PR TITLE
Fix sse_core.clj to use the updated API in the MCP Java SDK

### DIFF
--- a/src/clojure_mcp/sse_core.clj
+++ b/src/clojure_mcp/sse_core.clj
@@ -15,8 +15,7 @@
     #_McpServerFeatures$AsyncToolSpecification
     #_McpServerFeatures$AsyncResourceSpecification]
    [io.modelcontextprotocol.spec
-    McpSchema$ServerCapabilities]
-   [com.fasterxml.jackson.databind ObjectMapper]))
+    McpSchema$ServerCapabilities]))
 
 ;; helpers for setting up an sse mcp server
 


### PR DESCRIPTION
Version 0.17.2 of the MCP Java SDK has changed its API to instanciate HttpServletSseServerTransportProvider. This commit addresses the resulting failure when starting clj -X:mcp-sse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed server SSE transport provider initialization to a builder-based pattern; no changes to runtime behavior or public API surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->