### PR TITLE
Add dry_run to tool schemas for editing tools

### DIFF
--- a/src/clojure_mcp/tools/file_edit/tool.clj
+++ b/src/clojure_mcp/tools/file_edit/tool.clj
@@ -39,7 +39,10 @@ To make a file edit, provide the file_path, old_string (the text to replace), an
                 :old_string {:type :string
                              :description "The text to replace (must match the file contents exactly, including all whitespace and indentation)."}
                 :new_string {:type :string
-                             :description "The edited text to replace the old_string"}}
+                             :description "The edited text to replace the old_string"}
+                :dry_run {:type :string
+                          :enum ["diff" "new-source"]
+                          :description "Optional. Preview changes without writing: \"diff\" returns unified diff, \"new-source\" returns full modified source."}}
    :required [:file_path :old_string :new_string]})
 
 (defmethod tool-system/validate-inputs :file-edit [{:keys [nrepl-client-atom]} inputs]
@@ -65,6 +68,13 @@ To make a file edit, provide the file_path, old_string (the text to replace), an
     (when (= old_string new_string)
       (throw (ex-info "No changes to make: old_string and new_string are exactly the same."
                       {:inputs inputs})))
+
+    ;; Validate dry_run if provided
+    (let [dry_run (:dry_run inputs)]
+      (when (and (some? dry_run) (not (#{"diff" "new-source"} dry_run)))
+        (throw (ex-info (str "Invalid dry_run: " dry_run
+                             ". Supported values: diff, new-source")
+                        {:inputs inputs}))))
 
     ;; Validate path using the utility function
     (let [validated-path (valid-paths/validate-path-with-client file_path nrepl-client)]

--- a/src/clojure_mcp/tools/form_edit/combined_edit_tool.clj
+++ b/src/clojure_mcp/tools/form_edit/combined_edit_tool.clj
@@ -112,7 +112,10 @@ Note: For `defmethod` forms, be sure to include the dispatch value (`area :recta
                              :enum ["replace" "insert_before" "insert_after"]
                              :description "The editing operation to perform"}
                 "content" {:type "string"
-                           :description "New content to use for the operation"}}})
+                           :description "New content to use for the operation"}
+                "dry_run" {:type "string"
+                           :enum ["diff" "new-source"]
+                           :description "Optional. Preview changes without writing: \"diff\" returns unified diff, \"new-source\" returns full modified source."}}})
 
 ;; Validate inputs implementation
 (defmethod tool-system/validate-inputs :clojure-edit-form [{:keys [nrepl-client-atom]} inputs]
@@ -134,6 +137,10 @@ Note: For `defmethod` forms, be sure to include the dispatch value (`area :recta
                       {:inputs inputs})))
     (when-not content
       (throw (ex-info "Missing required parameter: content"
+                      {:inputs inputs})))
+    (when (and dry_run (not (#{"diff" "new-source"} dry_run)))
+      (throw (ex-info (str "Invalid dry_run: " dry_run
+                           ". Supported values: diff, new-source")
                       {:inputs inputs})))
     {:file_path file-path
      :form_name form_name

--- a/src/clojure_mcp/tools/form_edit/tool.clj
+++ b/src/clojure_mcp/tools/form_edit/tool.clj
@@ -57,7 +57,10 @@
             :replace_all {:type :boolean
                           :description
                           (format "Whether to %s all occurrences (default: false)"
-                                  (if multi-op "apply operation to" "replace"))}}
+                                  (if multi-op "apply operation to" "replace"))}
+            :dry_run {:type :string
+                      :enum ["diff" "new-source"]
+                      :description "Optional. Preview changes without writing: \"diff\" returns unified diff, \"new-source\" returns full modified source."}}
      multi-op
      (assoc :operation {:type :string
                         :enum ["replace" "insert_before" "insert_after"]
@@ -108,6 +111,10 @@
         (catch Exception e
           (throw (ex-info (str "Invalid Clojure code in new_form: " (.getMessage e))
                           {:inputs inputs})))))
+    (when (and dry_run (not (#{"diff" "new-source"} dry_run)))
+      (throw (ex-info (str "Invalid dry_run: " dry_run
+                           ". Supported values: diff, new-source")
+                      {:inputs inputs})))
     {:file_path file-path
      :match_form match_form
      :new_form new_form


### PR DESCRIPTION
## Summary

PR #121 added `dry_run` support to the editing tool pipelines (`file_edit`, `clojure_edit`, `clojure_edit_replace_sexp`), allowing clients to preview changes as a diff or full source without writing to disk. However, the `dry_run` parameter was only added to the pipeline and execution code — it was **not added to the `tool-schema` definitions**.

This means MCP clients that rely on the advertised tool schema to discover available parameters — such as Claude Code — have no way to know `dry_run` exists. Claude Code will only send parameters that appear in the tool's JSON schema, so in practice `dry_run` is unusable from Claude Code despite the backend fully supporting it.

This PR adds `dry_run` to the `:properties` map of the `tool-schema` multimethod for all three affected tools:

- `:file-edit` (`file_edit/tool.clj`)
- `:clojure-edit-form` (`form_edit/combined_edit_tool.clj`)
- `:clojure-update-sexp` (`form_edit/tool.clj`)

The parameter is optional (not in `:required`) with `enum ["diff" "new-source"]`, matching the existing pipeline behavior.

## Test plan

- [ ] Verify `dry_run: "diff"` returns a diff without writing the file for each of the three tools
- [ ] Verify `dry_run: "new-source"` returns full modified source without writing
- [ ] Verify omitting `dry_run` writes the file as before (no regression)
- [ ] Confirm the parameter appears in MCP tool schema responses (e.g. via `tools/list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dry_run option to file- and form-editing tools and the clojure-edit pipeline.
  * dry_run accepts "diff" (preview changes) and "new-source" (show proposed content) to inspect edits without applying them.
  * Inputs now validate dry_run values; invalid selections produce clear validation errors and prevent execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->