### PR TITLE
feat: add cljfmt :partial mode to format only replaced forms (#154)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -14,15 +14,17 @@ These basic settings affect how clojure-mcp interacts with your local system.
 Controls which directories the MCP tools can access for security. Paths can be relative (resolved from project root) or absolute.
 
 ### `:cljfmt`
-Boolean flag to enable/disable cljfmt formatting in editing pipelines (default: `true`). When disabled, file edits preserve the original formatting without applying cljfmt.
+Controls cljfmt formatting behavior in editing pipelines (default: `true`). Determines whether and how formatting is applied when editing Clojure forms.
 
 **Available values:**
-- `true` (default) - Applies cljfmt formatting to all edited files
-- `false` - Disables formatting, preserving exact whitespace and formatting
+- `true` (default) - Applies cljfmt formatting to the entire file after each edit
+- `:partial` - Formats only the replaced/inserted form in isolation, preserving surrounding formatting
+- `false` - Disables formatting entirely, preserving exact whitespace and formatting
 
 **When to use each setting:**
-- `true` - Best for maintaining consistent code style across your project
-- `false` - Useful when working with files that have specific formatting requirements or when you want to preserve manual formatting
+- `true` - Best for maintaining consistent code style across your project. Note: this reformats the entire file after each edit, which may introduce formatting changes to code you did not intend to modify.
+- `:partial` - Recommended for most workflows. Formats only the form being edited (fixing indentation, spacing, etc.) without touching the rest of the file. Prevents collateral formatting changes to unrelated code.
+- `false` - Useful when working with files that have specific formatting requirements or when you want to preserve manual formatting completely
 
 ### `:write-file-guard`
 Controls the file timestamp tracking behavior (default: `:partial-read`). This setting determines when file editing is allowed based on read operations.

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -135,8 +135,9 @@ your-project/
   - `:partial-read` - Both full and collapsed reads update timestamps (default)
   - `:full-read` - Only full reads update timestamps (safest)
   - `false` - Disables timestamp checking entirely
-- `cljfmt`: Boolean flag to enable/disable cljfmt formatting in editing pipelines (default: `true`)
-  - `true` - Applies cljfmt formatting to edited files (default behavior)
+- `cljfmt`: Controls cljfmt formatting in editing pipelines (default: `true`)
+  - `true` - Applies cljfmt formatting to entire file after edits (default behavior)
+  - `:partial` - Formats only the replaced/inserted form, preserving surrounding formatting
   - `false` - Disables formatting, preserving exact whitespace and formatting
 - `bash-over-nrepl`: Boolean flag to control bash command execution mode (default: `true`)
   - `true` - Execute bash commands over nREPL connection (default behavior)

--- a/src/clojure_mcp/config.clj
+++ b/src/clojure_mcp/config.clj
@@ -144,7 +144,9 @@
                   distinct
                   vec))
       (some? (:cljfmt config))
-      (assoc :cljfmt (boolean (:cljfmt config)))
+      (assoc :cljfmt (if (= :partial (:cljfmt config))
+                       :partial
+                       (boolean (:cljfmt config))))
       (some? (:bash-over-nrepl config))
       (assoc :bash-over-nrepl (boolean (:bash-over-nrepl config)))
       (some? (:nrepl-env-type config))
@@ -224,7 +226,12 @@
 (defn get-nrepl-user-dir [nrepl-client-map]
   (get-config nrepl-client-map :nrepl-user-dir))
 
-(defn get-cljfmt [nrepl-client-map]
+(defn get-cljfmt
+  "Returns the cljfmt setting: true (default), false, or :partial.
+   - true: full-file formatting via cljfmt after edits
+   - false: no formatting
+   - :partial: format only the replaced form in isolation, preserving surrounding formatting"
+  [nrepl-client-map]
   (let [value (get-config nrepl-client-map :cljfmt)]
     (if (nil? value)
       true ; Default to true when not specified

--- a/src/clojure_mcp/config/schema.clj
+++ b/src/clojure_mcp/config/schema.clj
@@ -261,7 +261,7 @@
    ;; Core configuration
    [:allowed-directories {:optional true} [:sequential Path]]
    [:write-file-guard {:optional true} [:enum :full-read :partial-read false]]
-   [:cljfmt {:optional true} :boolean]
+   [:cljfmt {:optional true} [:or :boolean [:= :partial]]]
    [:bash-over-nrepl {:optional true} :boolean]
    [:nrepl-env-type {:optional true} [:enum :clj :bb :basilisp :scittle]]
    [:start-nrepl-cmd {:optional true} [:sequential NonBlankString]]

--- a/src/clojure_mcp/tools/form_edit/core.clj
+++ b/src/clojure_mcp/tools/form_edit/core.clj
@@ -10,7 +10,8 @@
    [rewrite-clj.node :as n]
    [rewrite-clj.parser :as p]
    [rewrite-clj.zip :as z]
-   [clojure-mcp.utils.file :as file-utils]))
+   [clojure-mcp.utils.file :as file-utils]
+   [taoensso.timbre :as log]))
 
 ;; Form identification and location functions
 
@@ -275,6 +276,52 @@
    - The formatted source code string"
   [source-str formatting-options]
   (fmt/reformat-string source-str formatting-options))
+
+;; Partial formatting helpers
+
+(defn re-indent-to-column
+  "Re-indents a formatted form string so that:
+   - The first line is unchanged (it will be placed at the correct column by rewrite-clj)
+   - Subsequent lines are indented to align with the target column position.
+
+   Arguments:
+   - form-str: The formatted form string (formatted in isolation starting at column 1)
+   - target-col: The 1-based column where the form starts in the file
+
+   Returns:
+   - The re-indented form string"
+  [form-str target-col]
+  (if (<= target-col 1)
+    form-str
+    (let [lines (str/split form-str #"\n" -1)
+          indent-str (apply str (repeat (dec target-col) " "))
+          re-indented (cons (first lines)
+                            (map (fn [line]
+                                   (if (str/blank? line)
+                                     line
+                                     (str indent-str line)))
+                                 (rest lines)))]
+      (str/join "\n" re-indented))))
+
+(defn format-form-in-isolation
+  "Formats a form string in isolation using cljfmt, then re-indents it
+   to match the target column position. This avoids reformatting the
+   entire file when only one form is being replaced.
+
+   Arguments:
+   - form-str: The form source code to format
+   - target-col: The 1-based column where the form starts in the file
+   - formatting-options: cljfmt formatting options
+
+   Returns:
+   - The formatted and re-indented form string, or the original on failure"
+  [form-str target-col formatting-options]
+  (try
+    (let [formatted (fmt/reformat-string form-str formatting-options)]
+      (re-indent-to-column formatted target-col))
+    (catch Exception e
+      (log/debug "Partial formatting failed, using original form:" (.getMessage e))
+      form-str)))
 
 ;; File operations
 

--- a/src/clojure_mcp/tools/form_edit/pipeline.clj
+++ b/src/clojure_mcp/tools/form_edit/pipeline.clj
@@ -42,13 +42,16 @@
 
 (s/def ::dry-run (s/nilable #{"diff" "new-source"}))
 
+(s/def ::form-col pos-int?)
+
 (s/def ::context
   (s/keys :req [::file-path]
           :opt [::source ::old-content ::new-source-code ::top-level-def-name
                 ::top-level-def-type ::edit-type ::error ::message
                 ::zloc ::offsets ::lint-result ::docstring
                 ::comment-substring ::new-content ::expand-symbols
-                ::diff ::type ::output-source ::nrepl-client-atom ::dry-run]))
+                ::diff ::type ::output-source ::nrepl-client-atom ::dry-run
+                ::form-col]))
 
 ;; Pipeline helper functions
 
@@ -229,6 +232,43 @@
                      (str error-msg suggestion-msg)
                      error-msg)}))))
 
+(defn capture-form-position
+  "Captures the column position of the found form for partial formatting.
+   Must be called after find-form, before edit-form.
+   Saves ::form-col (1-based column) to the context when position is available.
+   Leaves ::form-col absent when z/position returns nil so downstream code
+   can fall back to full-file formatting rather than mis-indenting.
+
+   Requires ::zloc in the context (pointing to the found form)."
+  [ctx]
+  (let [zloc (::zloc ctx)]
+    (if-let [pos (z/position zloc)]
+      (assoc ctx ::form-col (second pos)) ;; [row col] -> col
+      ctx))) ;; leave ::form-col absent — downstream falls back to full-file formatting
+
+(defn format-new-source-partial
+  "Formats the new source code in isolation when cljfmt is set to :partial
+   and position tracking succeeded (::form-col is present in context).
+   Formats ::new-source-code using cljfmt, then re-indents to match the
+   target column position. This is done BEFORE insertion so the formatted
+   content replaces the old form without touching the rest of the file.
+
+   When ::form-col is absent (position tracking unavailable), passes through
+   unchanged so format-source falls back to full-file formatting.
+
+   Requires ::new-source-code, ::form-col, and ::nrepl-client-atom in context."
+  [ctx]
+  (let [nrepl-client-map (some-> ctx ::nrepl-client-atom deref)
+        cljfmt-setting (config/get-cljfmt nrepl-client-map)]
+    (if (and (= :partial cljfmt-setting) (::form-col ctx))
+      (let [new-source (::new-source-code ctx)
+            target-col (::form-col ctx)
+            formatting-options (core/project-formatting-options nrepl-client-map)
+            formatted (core/format-form-in-isolation new-source target-col formatting-options)]
+        (assoc ctx ::new-source-code formatted))
+      ;; Not :partial mode, or position unavailable — pass through
+      ctx)))
+
 (defn edit-form
   "Edits the form according to the specified edit type.
    Requires ::zloc, ::top-level-def-type, ::top-level-def-name, 
@@ -269,13 +309,25 @@
   "Formats the source code using the formatter.
    If formatting fails but the source is syntactically valid,
    returns the original source unchanged.
-   
+
+   When cljfmt is :partial AND the form was already formatted in isolation
+   (indicated by ::form-col in context), skips whole-file formatting.
+   Otherwise falls back to full-file formatting (e.g., for sexp-edit-pipeline
+   which doesn't do pre-insertion partial formatting).
+
    Requires ::output-source in the context.
    Updates ::output-source with the formatted code (or unchanged if formatting fails)."
   [ctx]
   (let [nrepl-client-map (some-> ctx ::nrepl-client-atom deref)
-        cljfmt-enabled (config/get-cljfmt nrepl-client-map)]
-    (if cljfmt-enabled
+        cljfmt-setting (config/get-cljfmt nrepl-client-map)]
+    (cond
+      ;; :partial mode with pre-formatted form - skip whole-file formatting
+      ;; ::form-col presence means format-new-source-partial already ran
+      (and (= :partial cljfmt-setting) (::form-col ctx))
+      ctx
+
+      ;; true (or :partial without pre-formatting) - full-file formatting
+      cljfmt-setting
       (try
         (let [source (::output-source ctx)
               formatting-options (core/project-formatting-options nrepl-client-map)
@@ -289,7 +341,9 @@
             ;; Only propagate error if we don't have valid source
             {::error true
              ::message (str "Failed to format source: " (.getMessage e))})))
-      ;; If cljfmt is disabled, return ctx unchanged
+
+      ;; false - formatting disabled, return ctx unchanged
+      :else
       ctx)))
 
 (defn determine-file-type
@@ -425,6 +479,8 @@
      enhance-defmethod-name
      parse-source
      find-form
+     capture-form-position
+     format-new-source-partial
      edit-form
      zloc->output-source
      format-source

--- a/test/clojure_mcp/config/schema_test.clj
+++ b/test/clojure_mcp/config/schema_test.clj
@@ -84,7 +84,14 @@
 
   (testing "Config with all nrepl-env-type values"
     (doseq [env-type [:clj :bb :basilisp :scittle]]
-      (is (schema/valid? {:nrepl-env-type env-type})))))
+      (is (schema/valid? {:nrepl-env-type env-type}))))
+
+  (testing "Config with cljfmt :partial"
+    (is (schema/valid? {:cljfmt :partial})))
+
+  (testing "Config with all cljfmt values"
+    (doseq [v [true false :partial]]
+      (is (schema/valid? {:cljfmt v})))))
 
 ;; ==============================================================================
 ;; Invalid Configuration Tests

--- a/test/clojure_mcp/tools/form_edit/pipeline_test.clj
+++ b/test/clojure_mcp/tools/form_edit/pipeline_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer [deftest testing is use-fixtures]]
    [clojure-mcp.config :as config]
    [clojure-mcp.tools.form-edit.pipeline :as sut]
+   [clojure-mcp.tools.form-edit.core :as core]
    [clojure-mcp.tools.test-utils :as test-utils]
    [rewrite-clj.zip :as z]
    [clojure.java.io :as io]
@@ -322,4 +323,417 @@
       (is (true? (::sut/error pipeline-result)))
       (is (string? (::sut/message pipeline-result)))
       (is (str/includes? (::sut/message pipeline-result) "not supported for definition editing")))))
+
+;; Tests for partial formatting (cljfmt :partial)
+
+(deftest re-indent-to-column-test
+  (testing "re-indent-to-column does nothing at column 1"
+    (let [form "(defn foo [x]\n  (+ x 1))"]
+      (is (= form (core/re-indent-to-column form 1)))))
+
+  (testing "re-indent-to-column adds indentation to subsequent lines"
+    (let [form "(defn foo [x]\n  (+ x 1))"
+          result (core/re-indent-to-column form 5)]
+      ;; First line unchanged, second line gets 4 spaces of extra indent
+      (is (= "(defn foo [x]\n      (+ x 1))" result))))
+
+  (testing "re-indent-to-column preserves blank lines"
+    (let [form "(defn foo [x]\n\n  (+ x 1))"
+          result (core/re-indent-to-column form 3)]
+      (is (= "(defn foo [x]\n\n    (+ x 1))" result))))
+
+  (testing "re-indent-to-column handles single-line form"
+    (let [form "(def x 1)"]
+      (is (= form (core/re-indent-to-column form 10))))))
+
+(deftest format-form-in-isolation-test
+  (testing "format-form-in-isolation formats and re-indents"
+    (let [form "(defn  foo[x]   (+ x 1))"
+          ;; Use default formatting options
+          opts core/default-formatting-options
+          result (core/format-form-in-isolation form 1 opts)]
+      ;; Should fix spacing issues
+      (is (str/includes? result "foo [x]"))
+      (is (not (str/includes? result "foo[x]")))))
+
+  (testing "format-form-in-isolation returns original on failure"
+    (let [form "(defn foo [x] (+ x 1))"
+          ;; Pass nil options to trigger an error
+          result (core/format-form-in-isolation form 1 nil)]
+      ;; Should return original form on failure
+      (is (= form result)))))
+
+(deftest capture-form-position-test
+  (testing "capture-form-position records column 1 for top-level form"
+    (let [source "(ns test.core)\n\n(defn example-fn [x y]\n  (+ x y))"
+          ctx {::sut/source source
+               ::sut/top-level-def-type "defn"
+               ::sut/top-level-def-name "example-fn"}
+          parsed (sut/parse-source ctx)
+          found (sut/find-form parsed)
+          result (sut/capture-form-position found)]
+      (is (= 1 (::sut/form-col result)))))
+
+  (testing "capture-form-position records column > 1 for nested form"
+    ;; defn inside a reader conditional: #?(:clj (defn ...))
+    ;; The (defn starts at column 9:
+    ;; #?(:clj (defn nested-fn ...
+    ;; 123456789
+    (let [source "#?(:clj (defn nested-fn [x]\n           (+ x 1)))"
+          ctx {::sut/source source
+               ::sut/top-level-def-type "defn"
+               ::sut/top-level-def-name "nested-fn"}
+          parsed (sut/parse-source ctx)
+          found (sut/find-form parsed)
+          result (sut/capture-form-position found)]
+      (is (not (::sut/error found))
+          (str "find-form failed: " (::sut/message found)))
+      (is (= 9 (::sut/form-col result))
+          "Nested form should be at column 9"))))
+
+(deftest capture-form-position-missing-position-test
+  (testing "capture-form-position leaves ::form-col absent when position tracking is unavailable"
+    (with-redefs [z/position (fn [_] nil)]
+      (let [ctx {::sut/zloc :dummy-zloc}
+            result (sut/capture-form-position ctx)]
+        (is (nil? (::sut/form-col result)))))))
+
+(deftest format-source-partial-skips-whole-file-test
+  (testing "format-source skips whole-file formatting when cljfmt is :partial"
+    ;; Set cljfmt to :partial
+    (config/set-config! *nrepl-client-atom* :cljfmt :partial)
+    (try
+      ;; Source with intentional bad formatting in the ns form (should be preserved)
+      ;; ::form-col signals that format-new-source-partial already ran
+      (let [source "(ns   test.core)\n\n(defn example-fn [x y]\n  (+ x y))"
+            ctx {::sut/nrepl-client-atom *nrepl-client-atom*
+                 ::sut/output-source source
+                 ::sut/form-col 1}
+            result (sut/format-source ctx)]
+        ;; With :partial + ::form-col, format-source should return the source unchanged
+        (is (= source (::sut/output-source result)))
+        ;; The extra spaces in ns should be preserved
+        (is (str/includes? (::sut/output-source result) "(ns   test.core)")))
+      (finally
+        ;; Restore default
+        (config/set-config! *nrepl-client-atom* :cljfmt true)))))
+
+(deftest format-new-source-partial-no-form-col-test
+  (testing "format-new-source-partial passes through unchanged when ::form-col is absent in :partial mode"
+    (config/set-config! *nrepl-client-atom* :cljfmt :partial)
+    (try
+      ;; Source with wrong indentation (3 spaces instead of 2).
+      ;; Sanity-check: confirm cljfmt *would* change this if it ran.
+      (let [source "(defn foo [x]\n   x)"
+            formatted (core/format-form-in-isolation source 1 core/default-formatting-options)]
+        (is (not= source formatted)
+            "sanity: cljfmt must change this source, otherwise the guard test proves nothing"))
+      (let [source "(defn foo [x]\n   x)"
+            ctx {::sut/nrepl-client-atom *nrepl-client-atom*
+                 ::sut/new-source-code source}
+            ;; No ::form-col in ctx — position tracking unavailable
+            result (sut/format-new-source-partial ctx)]
+        (is (= source (::sut/new-source-code result))
+            "source should be unchanged when ::form-col is absent"))
+      (finally
+        (config/set-config! *nrepl-client-atom* :cljfmt true)))))
+
+(deftest edit-form-pipeline-partial-formatting-test
+  (testing "partial formatting only formats the replaced form, not surrounding code"
+    ;; Set cljfmt to :partial
+    (config/set-config! *nrepl-client-atom* :cljfmt :partial)
+    (try
+      ;; Create a file with intentionally "bad" formatting in the ns form
+      ;; that cljfmt would normally fix (extra spaces)
+      (let [test-dir (test-utils/create-test-dir)
+            quirky-content (str "(ns   test.core)\n\n"
+                                "(defn example-fn\n  [x y]\n  (+ x y))\n\n"
+                                "(def   a     1)\n")
+            file-path (test-utils/create-and-register-test-file
+                       *nrepl-client-atom* test-dir "quirky.clj" quirky-content)
+            ;; Replace example-fn with badly-formatted version
+            pipeline-result (sut/edit-form-pipeline
+                             file-path
+                             "example-fn"
+                             "defn"
+                             "(defn example-fn   [x y]\n  (* x y))"
+                             :replace
+                             nil
+                             {:nrepl-client-atom *nrepl-client-atom*})
+            result (sut/format-result pipeline-result)
+            file-content (slurp file-path)]
+        (is (false? (:error result))
+            (str "Pipeline error: " (:message result)))
+        ;; The replaced form should be formatted (extra spaces fixed)
+        (is (str/includes? file-content "(defn example-fn [x y]")
+            "Replaced form should be formatted")
+        (is (str/includes? file-content "(* x y)")
+            "New implementation should be present")
+        ;; The ns form's quirky formatting should be PRESERVED (not reformatted)
+        (is (str/includes? file-content "(ns   test.core)")
+            "Surrounding ns form formatting should be preserved with :partial")
+        ;; The def's quirky formatting should also be PRESERVED
+        (is (str/includes? file-content "(def   a     1)")
+            "Surrounding def formatting should be preserved with :partial")
+        ;; Cleanup
+        (test-utils/clean-test-dir test-dir))
+      (finally
+        (config/set-config! *nrepl-client-atom* :cljfmt true)))))
+
+(deftest edit-form-pipeline-full-formatting-test
+  (testing "full formatting (cljfmt true) reformats the entire file"
+    ;; Ensure cljfmt is true (default)
+    (config/set-config! *nrepl-client-atom* :cljfmt true)
+    (let [test-dir (test-utils/create-test-dir)
+          quirky-content (str "(ns   test.core)\n\n"
+                              "(defn example-fn\n  [x y]\n  (+ x y))\n\n"
+                              "(def   a     1)\n")
+          file-path (test-utils/create-and-register-test-file
+                     *nrepl-client-atom* test-dir "quirky_full.clj" quirky-content)
+          pipeline-result (sut/edit-form-pipeline
+                           file-path
+                           "example-fn"
+                           "defn"
+                           "(defn example-fn [x y]\n  (* x y))"
+                           :replace
+                           nil
+                           {:nrepl-client-atom *nrepl-client-atom*})
+          result (sut/format-result pipeline-result)
+          file-content (slurp file-path)]
+      (is (false? (:error result))
+          (str "Pipeline error: " (:message result)))
+      ;; With full formatting, the ns form's extra spaces should be removed
+      (is (not (str/includes? file-content "(ns   test.core)"))
+          "Full formatting should fix ns form spacing")
+      (is (str/includes? file-content "(ns test.core)")
+          "Full formatting should normalize ns form")
+      ;; Cleanup
+      (test-utils/clean-test-dir test-dir))))
+
+(deftest sexp-edit-pipeline-partial-fallback-test
+  (testing "sexp-edit-pipeline falls back to full-file formatting when cljfmt is :partial"
+    ;; Set cljfmt to :partial
+    (config/set-config! *nrepl-client-atom* :cljfmt :partial)
+    (try
+      (let [test-dir (test-utils/create-test-dir)
+            content (str "(ns test.core)\n\n"
+                         "(defn example-fn [x y]\n  (+   x   y))\n")
+            file-path (test-utils/create-and-register-test-file
+                       *nrepl-client-atom* test-dir "sexp_partial.clj" content)
+            pipeline-result (sut/sexp-edit-pipeline
+                             file-path
+                             "(+   x   y)"
+                             "(* x y)"
+                             :replace
+                             false
+                             false
+                             nil
+                             {:nrepl-client-atom *nrepl-client-atom*})
+            result (sut/format-result pipeline-result)
+            file-content (slurp file-path)]
+        (is (false? (:error result))
+            (str "Pipeline error: " (:message result)))
+        ;; The replacement should be present
+        (is (str/includes? file-content "(* x y)")
+            "Replacement form should be present")
+        ;; Full-file formatting should still run (fallback behavior)
+        ;; so the file should be properly formatted
+        (is (str/includes? file-content "(defn example-fn [x y]")
+            "File should be formatted by full-file cljfmt fallback")
+        ;; Cleanup
+        (test-utils/clean-test-dir test-dir))
+      (finally
+        (config/set-config! *nrepl-client-atom* :cljfmt true)))))
+
+(deftest edit-form-pipeline-partial-before-test
+  (testing "partial formatting with :before edit type preserves surrounding formatting"
+    (config/set-config! *nrepl-client-atom* :cljfmt :partial)
+    (try
+      (let [test-dir (test-utils/create-test-dir)
+            quirky-content (str "(ns   test.core)\n\n"
+                                "(defn example-fn\n  [x y]\n  (+ x y))\n")
+            file-path (test-utils/create-and-register-test-file
+                       *nrepl-client-atom* test-dir "before_partial.clj" quirky-content)
+            pipeline-result (sut/edit-form-pipeline
+                             file-path
+                             "example-fn"
+                             "defn"
+                             "(defn   helper-fn   [z]\n  (inc z))"
+                             :before
+                             nil
+                             {:nrepl-client-atom *nrepl-client-atom*})
+            result (sut/format-result pipeline-result)
+            file-content (slurp file-path)]
+        (is (false? (:error result))
+            (str "Pipeline error: " (:message result)))
+        ;; The inserted form should be formatted (extra spaces fixed)
+        (is (str/includes? file-content "(defn helper-fn [z]")
+            "Inserted form should be formatted")
+        ;; The ns form's quirky formatting should be PRESERVED
+        (is (str/includes? file-content "(ns   test.core)")
+            "Surrounding ns form formatting should be preserved with :partial")
+        ;; Original function should still be present
+        (is (str/includes? file-content "(defn example-fn")
+            "Original form should still exist")
+        ;; Cleanup
+        (test-utils/clean-test-dir test-dir))
+      (finally
+        (config/set-config! *nrepl-client-atom* :cljfmt true)))))
+
+(deftest edit-form-pipeline-partial-after-test
+  (testing "partial formatting with :after edit type preserves surrounding formatting"
+    (config/set-config! *nrepl-client-atom* :cljfmt :partial)
+    (try
+      (let [test-dir (test-utils/create-test-dir)
+            quirky-content (str "(ns   test.core)\n\n"
+                                "(defn example-fn\n  [x y]\n  (+ x y))\n")
+            file-path (test-utils/create-and-register-test-file
+                       *nrepl-client-atom* test-dir "after_partial.clj" quirky-content)
+            pipeline-result (sut/edit-form-pipeline
+                             file-path
+                             "example-fn"
+                             "defn"
+                             "(defn   helper-fn   [z]\n  (inc z))"
+                             :after
+                             nil
+                             {:nrepl-client-atom *nrepl-client-atom*})
+            result (sut/format-result pipeline-result)
+            file-content (slurp file-path)]
+        (is (false? (:error result))
+            (str "Pipeline error: " (:message result)))
+        ;; The inserted form should be formatted (extra spaces fixed)
+        (is (str/includes? file-content "(defn helper-fn [z]")
+            "Inserted form should be formatted")
+        ;; The ns form's quirky formatting should be PRESERVED
+        (is (str/includes? file-content "(ns   test.core)")
+            "Surrounding ns form formatting should be preserved with :partial")
+        ;; Original function should still be present
+        (is (str/includes? file-content "(defn example-fn")
+            "Original form should still exist")
+        ;; Cleanup
+        (test-utils/clean-test-dir test-dir))
+      (finally
+        (config/set-config! *nrepl-client-atom* :cljfmt true)))))
+
+(deftest re-indent-to-column-nested-form-test
+  (testing "re-indent-to-column correctly indents multi-line form at column > 1"
+    (let [;; Simulate a form formatted in isolation that will live at column 8
+          ;; (e.g., inside a reader conditional: #?(:clj (defn ...)))
+          form "(defn foo [x]\n  (+ x 1)\n  (- x 2))"
+          result (core/re-indent-to-column form 8)]
+      ;; First line unchanged, subsequent lines get 7 spaces prepended
+      (is (= "(defn foo [x]\n         (+ x 1)\n         (- x 2))" result))))
+
+  (testing "format-form-in-isolation formats and re-indents at column > 1"
+    (let [;; Multi-line form destined for column 5
+          form "(defn foo [x]\n  (+ x 1))"
+          opts core/default-formatting-options
+          result (core/format-form-in-isolation form 5 opts)]
+      ;; First line unchanged, second line gets 4 extra spaces (col 5 = 4-space indent)
+      (is (= "(defn foo [x]\n      (+ x 1))" result)))))
+
+(deftest process-config-cljfmt-partial-roundtrip-test
+  (testing "process-config preserves :partial cljfmt setting"
+    (let [test-dir (System/getProperty "user.dir")
+          processed (config/process-config {:cljfmt :partial} test-dir)]
+      (is (= :partial (:cljfmt processed))
+          ":partial should survive process-config")))
+
+  (testing "process-config coerces truthy cljfmt to boolean"
+    (let [test-dir (System/getProperty "user.dir")
+          processed (config/process-config {:cljfmt true} test-dir)]
+      (is (true? (:cljfmt processed)))))
+
+  (testing "process-config coerces falsy cljfmt to boolean"
+    (let [test-dir (System/getProperty "user.dir")
+          processed (config/process-config {:cljfmt false} test-dir)]
+      (is (false? (:cljfmt processed))))))
+
+;; E2E test reproducing issue #154 exact scenario
+;; https://github.com/bhauman/clojure-mcp/issues/154
+
+(deftest issue-154-e2e-test
+  (testing "issue #154: replacing bar should NOT change alignment in unrelated defs"
+    ;; Exact file content from the issue
+    (let [issue-content (str "(ns example.core)\n\n"
+                             "(def ob-yes-heavy\n"
+                             "  {:orderbook {:yes [[60 200] [55 150]]\n"
+                             "               :no  [[40 80]  [35 60]]}})\n\n"
+                             "(def ob-empty-no  {:orderbook {:yes [[60 100]] :no []}})\n"
+                             "(def ob-empty     {:orderbook {:yes [] :no []}})\n\n"
+                             "(defn foo [x] (+ x 1))\n\n"
+                             "(defn bar [x] (+ x 2))\n")]
+
+      ;; Test with :partial — only bar should change
+      (config/set-config! *nrepl-client-atom* :cljfmt :partial)
+      (try
+        (let [test-dir (test-utils/create-test-dir)
+              file-path (test-utils/create-and-register-test-file
+                         *nrepl-client-atom* test-dir "issue154.clj" issue-content)
+              pipeline-result (sut/edit-form-pipeline
+                               file-path
+                               "bar"
+                               "defn"
+                               "(defn bar [x] (+ x 3))"
+                               :replace
+                               nil
+                               {:nrepl-client-atom *nrepl-client-atom*})
+              result (sut/format-result pipeline-result)
+              file-content (slurp file-path)]
+          (is (false? (:error result))
+              (str "Pipeline error: " (:message result)))
+          ;; The replaced form should have the new implementation
+          (is (str/includes? file-content "(defn bar [x] (+ x 3))")
+              "bar should have new implementation")
+          ;; Alignment spacing in unrelated defs must be PRESERVED
+          (is (str/includes? file-content ":no  [[40 80]  [35 60]]")
+              "Alignment in ob-yes-heavy :no should be preserved (double space before [[40)")
+          (is (str/includes? file-content "(def ob-empty-no  {:orderbook")
+              "Double space after ob-empty-no should be preserved")
+          (is (str/includes? file-content "(def ob-empty     {:orderbook")
+              "Alignment spaces in ob-empty should be preserved")
+          ;; foo should be completely untouched
+          (is (str/includes? file-content "(defn foo [x] (+ x 1))")
+              "foo should be untouched")
+          ;; ns should be untouched
+          (is (str/includes? file-content "(ns example.core)")
+              "ns should be untouched")
+          ;; Cleanup
+          (test-utils/clean-test-dir test-dir))
+        (finally
+          (config/set-config! *nrepl-client-atom* :cljfmt true)))))
+
+  (testing "issue #154 contrast: cljfmt true DOES destroy alignment (the bug)"
+    ;; Same file, but with cljfmt true — shows the problem the issue reports
+    (config/set-config! *nrepl-client-atom* :cljfmt true)
+    (let [issue-content (str "(ns example.core)\n\n"
+                             "(def ob-yes-heavy\n"
+                             "  {:orderbook {:yes [[60 200] [55 150]]\n"
+                             "               :no  [[40 80]  [35 60]]}})\n\n"
+                             "(def ob-empty-no  {:orderbook {:yes [[60 100]] :no []}})\n"
+                             "(def ob-empty     {:orderbook {:yes [] :no []}})\n\n"
+                             "(defn foo [x] (+ x 1))\n\n"
+                             "(defn bar [x] (+ x 2))\n")
+          test-dir (test-utils/create-test-dir)
+          file-path (test-utils/create-and-register-test-file
+                     *nrepl-client-atom* test-dir "issue154_full.clj" issue-content)
+          pipeline-result (sut/edit-form-pipeline
+                           file-path
+                           "bar"
+                           "defn"
+                           "(defn bar [x] (+ x 3))"
+                           :replace
+                           nil
+                           {:nrepl-client-atom *nrepl-client-atom*})
+          result (sut/format-result pipeline-result)
+          file-content (slurp file-path)]
+      (is (false? (:error result))
+          (str "Pipeline error: " (:message result)))
+      ;; With full formatting, alignment IS destroyed (this is the bug #154 reports)
+      (is (not (str/includes? file-content "(def ob-empty-no  {:orderbook"))
+          "Full formatting destroys double-space alignment in ob-empty-no")
+      (is (not (str/includes? file-content "(def ob-empty     {:orderbook"))
+          "Full formatting destroys alignment spaces in ob-empty")
+      ;; Cleanup
+      (test-utils/clean-test-dir test-dir))))
 


### PR DESCRIPTION
## Summary
- Adds `:partial` mode for `:cljfmt` config that formats only the replaced/inserted form in isolation, preserving surrounding file formatting
- Fixes #154 — `clojure_edit` replace was reformatting the entire file via cljfmt, causing collateral whitespace changes to unrelated code

## Approach
Per your guidance in #154: format the replacement content in isolation, then re-indent to match the target column position.

- **Before insertion:** cljfmt formats the new form string, then `re-indent-to-column` adjusts indentation for the target position
- **After insertion:** `format-source` skips whole-file formatting (the form is already formatted)
- **sexp-edit-pipeline:** Falls back to full-file formatting in `:partial` mode (no position tracking for arbitrary s-expression matching)

## Changes
- `config/schema.clj` — `:cljfmt` accepts `[:or :boolean [:= :partial]]`
- `config.clj` — `process-config` preserves `:partial`; `get-cljfmt` documents 3 values
- `form_edit/core.clj` — Two new pure functions: `re-indent-to-column`, `format-form-in-isolation`
- `form_edit/pipeline.clj` — Two new pipeline steps: `capture-form-position`, `format-new-source-partial`; `format-source` updated to 3-way cond
- `CONFIG.md` / `PROJECT_SUMMARY.md` — Documentation

## Config usage
```edn
{:cljfmt :partial}  ;; format only the edited form
{:cljfmt true}      ;; full-file formatting (default, unchanged)
{:cljfmt false}     ;; no formatting (unchanged)
```

## Test plan
- [x] 298 tests, 2153 assertions, 0 failures
- [x] Unit tests for `re-indent-to-column` (col 1, col > 1, blank lines, single-line)
- [x] Unit tests for `format-form-in-isolation` (success + failure fallback)
- [x] `capture-form-position` tested at col 1 and col 9 (nested reader conditional)
- [x] E2E: `:partial` + `:replace` — target formatted, surrounding `(ns   test.core)` preserved
- [x] E2E: `:partial` + `:before` and `:after` — inserted form formatted, surrounding preserved
- [x] E2E: `true` mode contrast — confirms `(ns   test.core)` gets normalized
- [x] sexp-edit-pipeline + `:partial` — falls back to full-file formatting
- [x] `process-config` round-trip — `:partial` survives EDN → config processing
- [x] Schema validates all three values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `:partial` cljfmt mode that formats only the edited form, preserving surrounding formatting.

* **Behavior**
  * Editing honors `:partial`, skipping full-file reformat when applicable; `true` remains full-file, `false` disables formatting. Partial edits preserve alignment and fallback safely on failure.

* **Documentation**
  * Docs updated to explain `true` (full-file), `:partial` (form-only), and `false` (disabled).

* **Tests**
  * Expanded tests covering schema acceptance, partial/full formatting, alignment, and fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->