### PR TITLE
fix: auto-correct dash-to-underscore filename mismatches in path validation (#48)

### DIFF
--- a/src/clojure_mcp/utils/valid_paths.clj
+++ b/src/clojure_mcp/utils/valid_paths.clj
@@ -58,16 +58,53 @@
 (defn path-exists? [path]
   (.exists (io/file path)))
 
+(def ^:private clojure-source-extensions
+  "Clojure source extensions that follow the namespace-to-filename
+   dash-to-underscore convention. Shared by clojure-source-ext? and clojure-file?."
+  #{".clj" ".cljs" ".cljc"})
+
+(defn- clojure-source-ext?
+  "Returns true if the file path has a Clojure source extension (.clj, .cljs, .cljc)
+   that follows the dash-to-underscore filename convention."
+  [file-path]
+  (when file-path
+    (let [lower-path (str/lower-case file-path)]
+      (some #(str/ends-with? lower-path %) clojure-source-extensions))))
+
+(defn- try-dash-to-underscore-correction
+  "When a validated path doesn't exist and has a Clojure source extension,
+   tries replacing dashes with underscores in the filename part only
+   (not directory components). Returns the re-validated corrected path
+   if the file exists, nil otherwise."
+  [validated-path current-dir allowed-dirs]
+  (when (clojure-source-ext? validated-path)
+    (let [file (io/file validated-path)
+          parent (.getParentFile file)
+          filename (.getName file)
+          corrected-filename (str/replace filename "-" "_")]
+      (when (not= filename corrected-filename)
+        (let [corrected-file (if parent
+                               (io/file parent corrected-filename)
+                               (io/file corrected-filename))
+              corrected-path (.getPath corrected-file)]
+          (when (path-exists? corrected-path)
+            ;; Re-validate for defense-in-depth (symlink protection)
+            (validate-path corrected-path current-dir allowed-dirs)))))))
+
 (defn validate-path-with-client
   "Validates a path using settings from the nrepl-client.
-   
+
    Parameters:
    - path: The path to validate (can be relative or absolute)
    - nrepl-client-map: The nREPL client map (dereferenced atom)
-   
+
    Returns:
    - The normalized absolute path if valid
-   - Throws an exception if the path is invalid or if required settings are missing"
+   - Throws an exception if the path is invalid or if required settings are missing
+
+   When the validated path doesn't exist and has a Clojure source extension
+   (.clj, .cljs, .cljc), tries replacing dashes with underscores in the
+   filename (not directory components) and returns the corrected path if it exists."
   [path nrepl-client]
   (let [current-dir (config/get-nrepl-user-dir nrepl-client)
         allowed-dirs (config/get-allowed-directories nrepl-client)]
@@ -80,7 +117,11 @@
       (throw (ex-info "Missing allowed-directories in config"
                       {:client-keys (keys nrepl-client)})))
 
-    (validate-path path current-dir allowed-dirs)))
+    (let [validated (validate-path path current-dir allowed-dirs)]
+      (if (path-exists? validated)
+        validated
+        (or (try-dash-to-underscore-correction validated current-dir allowed-dirs)
+            validated)))))
 
 (defn- babashka-shebang?
   [file-path]
@@ -107,9 +148,7 @@
   [file-path]
   (when file-path
     (let [lower-path (str/lower-case file-path)]
-      (or (str/ends-with? lower-path ".clj")
-          (str/ends-with? lower-path ".cljs")
-          (str/ends-with? lower-path ".cljc")
+      (or (clojure-source-ext? file-path)
           (str/ends-with? lower-path ".bb")
           (str/ends-with? lower-path ".lpy")
           (str/ends-with? lower-path ".edn")

--- a/test/clojure_mcp/tools/unified_read_file/tool_test.clj
+++ b/test/clojure_mcp/tools/unified_read_file/tool_test.clj
@@ -5,7 +5,8 @@
    [clojure-mcp.tools.unified-read-file.tool :as unified-read-file-tool]
    [clojure-mcp.tool-system :as tool-system]
    [clojure-mcp.config :as config]
-   [clojure.java.io :as io]))
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
 
 ;; Setup test fixtures
 (test-utils/apply-fixtures *ns*)
@@ -27,9 +28,10 @@
       (try
         (f)
         (finally
-          ;; Clean up
+          ;; Clean up all files recursively
           (when (.exists test-dir)
-            (.delete test-dir)))))))
+            (doseq [file (reverse (file-seq test-dir))]
+              (.delete file))))))))
 
 (use-fixtures :each setup-test-files-fixture)
 
@@ -93,3 +95,91 @@
           formatted-str (first formatted)]
       (is (not (re-find #"truncated" formatted-str))
           "Should not show truncation message when not truncated"))))
+
+;; --- Dash-to-underscore filename correction integration tests ---
+;; The core correction logic is tested in valid_paths_test.clj.
+;; These tests verify the read_file tool pipeline works with the correction.
+
+(deftest dash-to-underscore-correction-test
+  (testing "File with dashes requested, underscore version exists - reads successfully"
+    (let [underscore-file (io/file *test-dir* "core_stuff.clj")
+          _ (spit underscore-file "(ns core-stuff)\n(defn hello [] :world)")
+          tool-instance (unified-read-file-tool/create-unified-read-file-tool *nrepl-client-atom*)
+          dash-path (.getAbsolutePath (io/file *test-dir* "core-stuff.clj"))
+          validated (tool-system/validate-inputs tool-instance {:path dash-path})
+          result (tool-system/execute-tool tool-instance validated)
+          formatted (tool-system/format-results tool-instance result)]
+      ;; Should succeed (not error)
+      (is (not (:error formatted)) "Should successfully read the corrected file")
+      ;; Should contain the actual file content
+      (is (some #(str/includes? % "core-stuff") (:result formatted))
+          "Should contain the file content")
+      (.delete underscore-file)))
+
+  (testing "File with underscores requested directly - reads successfully"
+    (let [underscore-file (io/file *test-dir* "core_stuff.clj")
+          _ (spit underscore-file "(ns core-stuff)\n(defn hello [] :world)")
+          tool-instance (unified-read-file-tool/create-unified-read-file-tool *nrepl-client-atom*)
+          underscore-path (.getAbsolutePath underscore-file)
+          validated (tool-system/validate-inputs tool-instance {:path underscore-path})
+          result (tool-system/execute-tool tool-instance validated)
+          formatted (tool-system/format-results tool-instance result)]
+      (is (not (:error formatted)) "Should successfully read the file")
+      (.delete underscore-file)))
+
+  (testing "Neither dash nor underscore version exists - returns normal error"
+    (let [tool-instance (unified-read-file-tool/create-unified-read-file-tool *nrepl-client-atom*)
+          non-existent-path (.getAbsolutePath (io/file *test-dir* "no-such-file.clj"))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"does not exist"
+                            (tool-system/validate-inputs tool-instance {:path non-existent-path}))
+          "Should throw an error when neither file version exists")))
+
+  (testing "Non-Clojure files (.java) - do NOT auto-correct"
+    (let [underscore-file (io/file *test-dir* "core_stuff.java")
+          _ (spit underscore-file "public class core_stuff {}")
+          tool-instance (unified-read-file-tool/create-unified-read-file-tool *nrepl-client-atom*)
+          dash-path (.getAbsolutePath (io/file *test-dir* "core-stuff.java"))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"does not exist"
+                            (tool-system/validate-inputs tool-instance {:path dash-path}))
+          "Should NOT auto-correct non-Clojure file extensions")
+      (.delete underscore-file)))
+
+  (testing "Directory components with dashes - only filename corrected"
+    (let [dashed-dir (io/file *test-dir* "my-cool-dir")
+          _ (.mkdirs dashed-dir)
+          underscore-file (io/file dashed-dir "my_file.clj")
+          _ (spit underscore-file "(ns my-cool-dir.my-file)")
+          tool-instance (unified-read-file-tool/create-unified-read-file-tool *nrepl-client-atom*)
+          dash-path (.getAbsolutePath (io/file dashed-dir "my-file.clj"))
+          validated (tool-system/validate-inputs tool-instance {:path dash-path})
+          result (tool-system/execute-tool tool-instance validated)
+          formatted (tool-system/format-results tool-instance result)]
+      (is (not (:error formatted)) "Should read file with dashed directory and corrected filename")
+      (is (str/includes? (:path validated) "my-cool-dir")
+          "Directory dashes should be preserved")
+      (.delete underscore-file)
+      (.delete dashed-dir)))
+
+  (testing "Full pipeline through make-tool-tester with dash correction"
+    (let [underscore-file (io/file *test-dir* "pipeline_test.clj")
+          _ (spit underscore-file "(ns pipeline-test)\n(defn greet [name] (str \"Hello \" name))")
+          tool-instance (unified-read-file-tool/create-unified-read-file-tool *nrepl-client-atom*)
+          tool-fn (test-utils/make-tool-tester tool-instance)
+          dash-path (.getAbsolutePath (io/file *test-dir* "pipeline-test.clj"))
+          result (tool-fn {:path dash-path})]
+      (is (not (:error? result)) "Full pipeline should succeed with dash correction")
+      (.delete underscore-file)))
+
+  (testing "Babashka (.bb) files - do NOT auto-correct"
+    (let [underscore-file (io/file *test-dir* "my_script.bb")
+          _ (spit underscore-file "(println :hello)")
+          tool-instance (unified-read-file-tool/create-unified-read-file-tool *nrepl-client-atom*)
+          dash-path (.getAbsolutePath (io/file *test-dir* "my-script.bb"))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"does not exist"
+                            (tool-system/validate-inputs tool-instance {:path dash-path}))
+          "Should NOT auto-correct .bb files")
+      (.delete underscore-file))))
+

--- a/test/clojure_mcp/utils/valid_paths_test.clj
+++ b/test/clojure_mcp/utils/valid_paths_test.clj
@@ -1,6 +1,7 @@
 (ns clojure-mcp.utils.valid-paths-test
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]
+            [clojure.string :as str]
             [clojure-mcp.utils.valid-paths :as valid-paths]))
 
 (deftest extract-paths-from-bash-command-test
@@ -113,6 +114,123 @@
       (spit tmp "#!/bin/bash\necho hi")
       (is (not (valid-paths/clojure-file? (.getPath tmp))))
       (.delete tmp))))
+
+(deftest dash-to-underscore-correction-test
+  (let [test-dir (io/file (System/getProperty "java.io.tmpdir") "valid-paths-dash-test")
+        canonical-dir (.getCanonicalPath test-dir)
+        make-client (fn []
+                      {:clojure-mcp.config/config
+                       {:nrepl-user-dir canonical-dir
+                        :allowed-directories [canonical-dir]}})]
+    (try
+      (.mkdirs test-dir)
+
+      (testing "Clojure file with dashes corrected to underscores when underscore version exists"
+        (let [underscore-file (io/file test-dir "core_stuff.clj")
+              _ (spit underscore-file "(ns core-stuff)")
+              dash-path (.getAbsolutePath (io/file test-dir "core-stuff.clj"))
+              result (valid-paths/validate-path-with-client dash-path (make-client))]
+          (is (= (.getCanonicalPath underscore-file) result))
+          (.delete underscore-file)))
+
+      (testing "Non-Clojure files (.java) do NOT get corrected"
+        (let [underscore-file (io/file test-dir "core_stuff.java")
+              _ (spit underscore-file "public class core_stuff {}")
+              dash-path (.getAbsolutePath (io/file test-dir "core-stuff.java"))
+              result (valid-paths/validate-path-with-client dash-path (make-client))]
+          ;; Should return the original (dashed) path, not corrected
+          (is (not= (.getCanonicalPath underscore-file) result))
+          (.delete underscore-file)))
+
+      (testing "Non-Clojure files (.py) do NOT get corrected"
+        (let [underscore-file (io/file test-dir "my_module.py")
+              _ (spit underscore-file "def hello(): pass")
+              dash-path (.getAbsolutePath (io/file test-dir "my-module.py"))
+              result (valid-paths/validate-path-with-client dash-path (make-client))]
+          (is (not= (.getCanonicalPath underscore-file) result))
+          (.delete underscore-file)))
+
+      (testing "File where dashed version exists is returned as-is"
+        (let [dash-file (io/file test-dir "core-stuff.clj")
+              _ (spit dash-file "(ns core-stuff)")
+              dash-path (.getAbsolutePath dash-file)
+              result (valid-paths/validate-path-with-client dash-path (make-client))]
+          (is (= (.getCanonicalPath dash-file) result))
+          (.delete dash-file)))
+
+      (testing "Directory components with dashes are NOT changed, only filename"
+        (let [dashed-dir (io/file test-dir "my-cool-dir")
+              _ (.mkdirs dashed-dir)
+              underscore-file (io/file dashed-dir "my_file.clj")
+              _ (spit underscore-file "(ns my-cool-dir.my-file)")
+              dash-path (.getAbsolutePath (io/file dashed-dir "my-file.clj"))
+              result (valid-paths/validate-path-with-client dash-path (make-client))]
+          (is (= (.getCanonicalPath underscore-file) result))
+          (is (str/includes? result "my-cool-dir")
+              "Directory dashes should be preserved")
+          (.delete underscore-file)
+          (.delete dashed-dir)))
+
+      (testing ".cljs extension works"
+        (let [underscore-file (io/file test-dir "my_component.cljs")
+              _ (spit underscore-file "(ns my-component)")
+              dash-path (.getAbsolutePath (io/file test-dir "my-component.cljs"))
+              result (valid-paths/validate-path-with-client dash-path (make-client))]
+          (is (= (.getCanonicalPath underscore-file) result))
+          (.delete underscore-file)))
+
+      (testing ".cljc extension works"
+        (let [underscore-file (io/file test-dir "shared_utils.cljc")
+              _ (spit underscore-file "(ns shared-utils)")
+              dash-path (.getAbsolutePath (io/file test-dir "shared-utils.cljc"))
+              result (valid-paths/validate-path-with-client dash-path (make-client))]
+          (is (= (.getCanonicalPath underscore-file) result))
+          (.delete underscore-file)))
+
+      (testing ".bb files are NOT corrected"
+        (let [underscore-file (io/file test-dir "my_script.bb")
+              _ (spit underscore-file "(println :hello)")
+              dash-path (.getAbsolutePath (io/file test-dir "my-script.bb"))
+              result (valid-paths/validate-path-with-client dash-path (make-client))]
+          (is (not= (.getCanonicalPath underscore-file) result))
+          (.delete underscore-file)))
+
+      (testing "When neither dashed nor underscored file exists, returns original validated path"
+        (let [dash-path (.getAbsolutePath (io/file test-dir "no-such-file.clj"))
+              result (valid-paths/validate-path-with-client dash-path (make-client))]
+          ;; Should return the validated (but non-existent) path, not throw
+          (is (string? result))
+          (is (not (valid-paths/path-exists? result)))))
+
+      (testing "Case-insensitive extension matching"
+        (let [underscore-file (io/file test-dir "MY_THING.CLJ")
+              _ (spit underscore-file "(ns my-thing)")
+              dash-path (.getAbsolutePath (io/file test-dir "MY-THING.CLJ"))
+              result (valid-paths/validate-path-with-client dash-path (make-client))]
+          (is (= (.getCanonicalPath underscore-file) result))
+          (.delete underscore-file)))
+
+      (testing "Reverse direction: underscore requested, only dash exists - should NOT correct"
+        (let [dash-file (io/file test-dir "core-stuff.clj")
+              _ (spit dash-file "(ns core-stuff)")
+              underscore-path (.getAbsolutePath (io/file test-dir "core_stuff.clj"))
+              result (valid-paths/validate-path-with-client underscore-path (make-client))]
+          ;; Should return the underscore path (not found), not correct to dash
+          (is (not= (.getCanonicalPath dash-file) result))
+          (.delete dash-file)))
+
+      (testing "Mixed dashes and underscores in filename - corrects all dashes"
+        (let [underscore-file (io/file test-dir "my_cool_thing.clj")
+              _ (spit underscore-file "(ns my-cool-thing)")
+              dash-path (.getAbsolutePath (io/file test-dir "my-cool_thing.clj"))
+              result (valid-paths/validate-path-with-client dash-path (make-client))]
+          (is (= (.getCanonicalPath underscore-file) result))
+          (.delete underscore-file)))
+
+      (finally
+        (when (.exists test-dir)
+          (doseq [file (reverse (file-seq test-dir))]
+            (.delete file)))))))
 
 (deftest validate-bash-command-paths-test
   (let [test-dir (.getCanonicalPath (io/file (System/getProperty "java.io.tmpdir")))


### PR DESCRIPTION
## Summary
- Fixes #48 — LLMs commonly request Clojure files using namespace-style dashes (`core-stuff.clj`) when the filesystem uses underscores (`core_stuff.clj`)
- Adds transparent dash-to-underscore correction in `validate-path-with-client` so **all tools** (read_file, edit, grep, glob, etc.) get the fix for free
- Only corrects `.clj`, `.cljs`, `.cljc` files — extensions that follow the Clojure namespace-to-filename convention
- Only corrects the filename portion, preserving dashes in directory components
- Corrected path is re-validated for defense-in-depth (symlink protection)

## Approach
Per your review feedback: correction lives in `validate-path-with-client` in `valid_paths.clj`, not in the read_file tool. After `validate-path` returns, if the file doesn't exist and has a Clojure source extension, tries the underscore version. The tool already returns the path it read, so the LLM sees the corrected filename without needing an explicit notice.

## Changes
- `utils/valid_paths.clj` — `clojure-source-extensions` constant (shared with `clojure-file?`), `clojure-source-ext?` predicate, `try-dash-to-underscore-correction` helper, updated `validate-path-with-client`
- `utils/valid_paths_test.clj` — 12 unit test scenarios
- `tools/unified_read_file/tool_test.clj` — 7 integration tests through full tool pipeline + recursive fixture cleanup

## Test plan
- [x] 314 tests, 2273 assertions, 0 failures (rebased on v0.3.0)
- [x] .clj, .cljs, .cljc correction works
- [x] .bb, .edn, .lpy, .java, .py files are NOT corrected
- [x] Directory dashes preserved (only filename corrected)
- [x] Reverse direction (underscore→dash) does NOT correct
- [x] Mixed dashes/underscores corrected
- [x] Case-insensitive extension matching
- [x] Non-existent files return original path (caller handles error)
- [x] Full pipeline integration test via make-tool-tester

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic file lookup now tries dash-to-underscore filename conversion for Clojure sources when the requested file isn't found — applies to .clj/.cljs/.cljc, preserves directory dashes, and does not alter non-Clojure or Babashka files.

* **Tests**
  * Added comprehensive integration and unit tests covering conversion behavior, edge cases, error handling, and cleanup of test artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->