### PR TITLE
Add :fallback-nrepl option for spawning a local nREPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Opt-in nREPL fallback**: New `:fallback-nrepl` option. When set, ClojureMCP first probes `:port` and attaches if reachable; if not, it spawns a local nREPL on an **ephemeral** port (never the configured `:port`, so a later editor session can still claim it). The default command is built from clojure-mcp's own nREPL dependency, so no version is hardcoded, and `~/.clojure/deps.edn` is still merged in. Companion options `:fallback-nrepl-cmd` (override default command) and `:fallback-nrepl-dir` (working dir; default `:project-dir` or `$HOME`) are also available. Default behavior is unchanged — the flag is opt-in.
+
 ### Changed
 - **HTTP transport replaced with Streamable HTTP**: The legacy HTTP+SSE transport has been replaced with the MCP Streamable HTTP transport (`HttpServletStreamableServerTransportProvider`), which exposes a single `/mcp` endpoint for client POSTs, the server→client SSE stream (GET), and session termination (DELETE).
   - Namespaces renamed: `clojure-mcp.sse-core` → `clojure-mcp.streamable-http-core`, `clojure-mcp.sse-main` → `clojure-mcp.streamable-http-main`

--- a/README.md
+++ b/README.md
@@ -509,6 +509,27 @@ When used without `:port`, the MCP server will automatically parse the port from
 
 `:start-nrepl-cmd ["lein" "repl" ":headless"]` or `:start-nrepl-cmd ["clojure" "-M:nrepl"]`
 
+#### `:fallback-nrepl`
+**Optional** - When `true`, ClojureMCP will first try to attach to `:port`. If nothing is listening there (or `:port` is omitted entirely), it spawns a local nREPL on an **ephemeral** port and connects to that. The fallback never squats on your configured `:port`, so a later editor session can still claim it.
+
+This is intended for users who don't always have an editor-managed nREPL running — for example, when launching Claude Desktop without first starting a project REPL, or when working in small projects via Vim. Without this flag, ClojureMCP fails to start if it can't reach `:port`, which Claude Desktop surfaces as a "Server disconnected" error.
+
+The default command is built from clojure-mcp's own nREPL dependency (so no version is hardcoded) and runs through `clojure -Sdeps ... -M -m nrepl.cmdline`. The user's `~/.clojure/deps.edn` is still merged in by the `clojure` CLI, so libraries you keep globally available (e.g. Criterium) remain on the spawned REPL's classpath.
+
+The spawned process is cleaned up automatically when the MCP server shuts down.
+
+`:fallback-nrepl true`
+
+#### `:fallback-nrepl-cmd`
+**Optional** - Overrides the default fallback command. Must be a vector of strings. Only used when `:fallback-nrepl` is `true`. Do not include an explicit port in the command; the launcher needs to parse the discovered port from the process output.
+
+`:fallback-nrepl-cmd ["lein" "repl" ":headless"]`
+
+#### `:fallback-nrepl-dir`
+**Optional** - Working directory for the spawned fallback REPL. Defaults to `:project-dir` if set, otherwise to `$HOME`. Useful when you want the fallback REPL to pick up a project's `deps.edn` automatically.
+
+`:fallback-nrepl-dir "/path/to/scratch"`
+
 #### `:config-file`
 **Optional** - Specify the location of a configuration file. Must be a path to an existing file.
 
@@ -587,6 +608,11 @@ clojure -Tmcp start :start-nrepl-cmd '["clojure" "-M:nrepl"]'
 
 # Auto-start with explicit port (uses fixed port, no parsing)
 clojure -Tmcp start :port 7888 :start-nrepl-cmd '["clojure" "-M:nrepl"]'
+
+# Attach to port 7888 if available, otherwise spawn a fallback nREPL on
+# an ephemeral port. Useful for Claude Desktop when you don't always
+# have an editor-managed REPL running.
+clojure -Tmcp start :not-cwd true :port 7888 :fallback-nrepl true
 
 # For Claude Desktop: must provide project-dir since it doesn't run from your project
 clojure -Tmcp start :start-nrepl-cmd '["lein" "repl" ":headless"]' :project-dir '"/path/to/your/clojure/project"'

--- a/src/clojure_mcp/core.clj
+++ b/src/clojure_mcp/core.clj
@@ -454,9 +454,16 @@
 (s/def ::start-nrepl-cmd (s/coll-of string? :kind vector?))
 (s/def ::config-profile (s/or :keyword keyword? :symbol symbol? :string string?))
 (s/def ::shadow-cljs-repl-message boolean?)
+(s/def ::fallback-nrepl boolean?)
+(s/def ::fallback-nrepl-cmd (s/coll-of string? :kind vector?))
+(s/def ::fallback-nrepl-dir (s/and string?
+                                   #(try (let [f (io/file %)]
+                                           (and (.exists f) (.isDirectory f)))
+                                         (catch Exception _ false))))
 (s/def ::nrepl-args (s/keys :req-un []
                             :opt-un [::port ::host ::config-file ::project-dir ::nrepl-env-type
-                                     ::start-nrepl-cmd ::config-profile ::shadow-cljs-repl-message]))
+                                     ::start-nrepl-cmd ::config-profile ::shadow-cljs-repl-message
+                                     ::fallback-nrepl ::fallback-nrepl-cmd ::fallback-nrepl-dir]))
 
 (def nrepl-client-atom (atom nil))
 
@@ -660,7 +667,17 @@
      - :port (required if no :project-dir) - nREPL server port
      - :host (optional) - nREPL server host (defaults to localhost)
      - :project-dir (optional) - Root directory for the project. If provided, port is optional.
-     - :start-nrepl-cmd (optional) - Command to start nREPL server
+     - :start-nrepl-cmd (optional) - Command to start nREPL server (always
+       starts a fresh nREPL; ignored when :fallback-nrepl is also set)
+     - :fallback-nrepl (optional) - When true, attempts to attach to
+       :port first; if unreachable (or no :port given), spawns a local
+       nREPL on an ephemeral port. Does not collide with the configured
+       :port. See clojure-mcp.nrepl-launcher/maybe-start-fallback-nrepl.
+     - :fallback-nrepl-cmd (optional) - Override the default fallback
+       command. Vector of strings. Default uses `clojure` with nREPL
+       pulled in via -Sdeps.
+     - :fallback-nrepl-dir (optional) - Working directory for the
+       spawned fallback REPL. Default: :project-dir if set, else $HOME.
 
    - component-factories: Map with factory functions
      - :make-tools-fn - (fn [nrepl-client-atom working-dir] ...) returns seq of tools
@@ -670,11 +687,13 @@
    Auto-start conditions (must satisfy ONE):
    1. Both :start-nrepl-cmd AND :project-dir provided in nrepl-args
    2. Current directory contains .clojure-mcp/config.edn with :start-nrepl-cmd
+   3. :fallback-nrepl is true (handled separately by the fallback launcher)
 
    Returns: nil"
   [nrepl-args component-factories]
   (-> nrepl-args
       validate-options
+      nrepl-launcher/maybe-start-fallback-nrepl
       nrepl-launcher/maybe-start-nrepl-process
       ensure-port-if-needed
       (build-and-start-mcp-server-impl component-factories)))

--- a/src/clojure_mcp/main.clj
+++ b/src/clojure_mcp/main.clj
@@ -62,6 +62,15 @@
    Options:
    - :not-cwd - If true, does NOT set project-dir to cwd (default: false)
    - :port - Optional nREPL port (REPL is optional when project-dir is set)
+   - :fallback-nrepl - If true, attach to :port when reachable, otherwise
+     spawn a local nREPL on an ephemeral port (does not collide with
+     :port). Useful when you don't always have an editor-managed nREPL
+     running.
+   - :fallback-nrepl-cmd - Vector of strings overriding the default
+     fallback command. Default reuses clojure-mcp's own nREPL version
+     via -Sdeps so ~/.clojure/deps.edn is still merged in.
+   - :fallback-nrepl-dir - Working directory for the spawned fallback
+     REPL. Default: :project-dir if set, else $HOME.
    - :enable-tools - Allowlist of tool keywords, replaces config's :enable-tools
    - :disable-tools - Blocklist of tool keywords, replaces config's :disable-tools
    - :add-tools - Force-enable tools (removes from :disable-tools, adds to :enable-tools if set)

--- a/src/clojure_mcp/nrepl_launcher.clj
+++ b/src/clojure_mcp/nrepl_launcher.clj
@@ -7,7 +7,7 @@
             [clojure.string :as str]
             [nrepl.version :as nrepl-version]
             [taoensso.timbre :as log])
-  (:import [java.io BufferedReader]
+  (:import [java.io BufferedReader IOException]
            [java.net InetSocketAddress Socket]
            [java.util.concurrent TimeUnit]))
 
@@ -245,12 +245,15 @@
 
    Used by the fallback launcher to decide whether to attach to an
    already-running nREPL or spawn a new one."
-  [^String host ^long port ^long timeout-ms]
+  [^String host port timeout-ms]
   (try
     (with-open [socket (Socket.)]
       (.connect socket (InetSocketAddress. host (int port)) (int timeout-ms))
       true)
-    (catch Exception _ false)))
+    (catch IOException _ false)
+    (catch IllegalArgumentException e
+      (log/warn e "Invalid host/port passed to port-reachable?")
+      false)))
 
 (def ^:private fallback-probe-timeout-ms 500)
 
@@ -296,7 +299,10 @@
                                     {:start-nrepl-cmd cmd
                                      :project-dir dir})]
         (-> nrepl-args
-            (assoc :port port :nrepl-process process)
+            ;; Spawned fallback nREPL listens locally; override any
+            ;; user-supplied remote :host so the downstream connect
+            ;; targets the spawned process, not the unreachable host.
+            (assoc :host "localhost" :port port :nrepl-process process)
             (dissoc :fallback-nrepl :fallback-nrepl-cmd :fallback-nrepl-dir
                     :start-nrepl-cmd))))))
 

--- a/src/clojure_mcp/nrepl_launcher.clj
+++ b/src/clojure_mcp/nrepl_launcher.clj
@@ -5,9 +5,30 @@
             [clojure.java.io :as io]
             [clojure.java.process :as process]
             [clojure.string :as str]
+            [nrepl.version :as nrepl-version]
             [taoensso.timbre :as log])
   (:import [java.io BufferedReader]
+           [java.net InetSocketAddress Socket]
            [java.util.concurrent TimeUnit]))
+
+(defn default-fallback-nrepl-cmd
+  "Build the default command for the opt-in fallback nREPL.
+
+   The nREPL coordinate is taken from the version of nREPL that
+   clojure-mcp itself depends on (read from `nrepl.version`), so the
+   subprocess uses whatever version is already on clojure-mcp's
+   classpath rather than a hardcoded one.
+
+   The user's ~/.clojure/deps.edn is still merged in by the `clojure`
+   CLI, so commonly available dev libraries (Criterium, etc.) remain on
+   the spawned REPL's classpath."
+  []
+  ["clojure"
+   "-Sdeps"
+   (str "{:deps {nrepl/nrepl {:mvn/version \""
+        (:version-string nrepl-version/version)
+        "\"}}}")
+   "-M" "-m" "nrepl.cmdline"])
 
 (defn parse-port-from-output
   "Parse nREPL port number from process output.
@@ -217,6 +238,67 @@
   (if (and start-nrepl-cmd (not project-dir))
     (assoc nrepl-args :project-dir (System/getProperty "user.dir"))
     nrepl-args))
+
+(defn port-reachable?
+  "Probes whether a TCP connection can be opened to host:port within
+   timeout-ms. Returns true if the connection succeeds, false otherwise.
+
+   Used by the fallback launcher to decide whether to attach to an
+   already-running nREPL or spawn a new one."
+  [^String host ^long port ^long timeout-ms]
+  (try
+    (with-open [socket (Socket.)]
+      (.connect socket (InetSocketAddress. host (int port)) (int timeout-ms))
+      true)
+    (catch Exception _ false)))
+
+(def ^:private fallback-probe-timeout-ms 500)
+
+(defn maybe-start-fallback-nrepl
+  "If :fallback-nrepl is enabled, ensure an nREPL is reachable -
+   attaching to one if :port is provided and answering, otherwise
+   spawning a local nREPL using `default-fallback-nrepl-cmd` (or an
+   explicit :fallback-nrepl-cmd override).
+
+   The spawned REPL runs in :fallback-nrepl-dir (default: :project-dir
+   when supplied, else the user's home directory) so it inherits
+   ~/.clojure/deps.edn.
+
+   When :fallback-nrepl is true this path takes over from
+   :start-nrepl-cmd's always-start behaviour; :start-nrepl-cmd is
+   dropped from the returned args to prevent downstream double-start.
+
+   Returns nrepl-args possibly updated with the spawned :port and
+   :nrepl-process. Returns nrepl-args unchanged when the flag is unset."
+  [{:keys [fallback-nrepl host port project-dir
+           fallback-nrepl-cmd fallback-nrepl-dir]
+    :as nrepl-args}]
+  (cond
+    (not fallback-nrepl)
+    nrepl-args
+
+    (and port (port-reachable? (or host "localhost") port fallback-probe-timeout-ms))
+    (do
+      (log/debug "Fallback nREPL: existing nREPL reachable on port" port "- attaching")
+      (dissoc nrepl-args
+              :fallback-nrepl :fallback-nrepl-cmd :fallback-nrepl-dir
+              :start-nrepl-cmd))
+
+    :else
+    (let [cmd (or fallback-nrepl-cmd (default-fallback-nrepl-cmd))
+          dir (or fallback-nrepl-dir project-dir (System/getProperty "user.home"))]
+      (log/info "Fallback nREPL:"
+                (if port
+                  (str "port " port " unreachable;")
+                  "no port provided;")
+                "spawning local nREPL in" dir)
+      (let [{:keys [port process]} (start-nrepl-process
+                                    {:start-nrepl-cmd cmd
+                                     :project-dir dir})]
+        (-> nrepl-args
+            (assoc :port port :nrepl-process process)
+            (dissoc :fallback-nrepl :fallback-nrepl-cmd :fallback-nrepl-dir
+                    :start-nrepl-cmd))))))
 
 (defn maybe-start-nrepl-process
   "Main wrapper that conditionally starts an nREPL process.

--- a/test/clojure_mcp/nrepl_launcher_test.clj
+++ b/test/clojure_mcp/nrepl_launcher_test.clj
@@ -1,7 +1,8 @@
 (ns clojure-mcp.nrepl-launcher-test
   (:require [clojure.test :refer [deftest testing is are]]
             [clojure-mcp.nrepl-launcher :as launcher])
-  (:import [java.io File]))
+  (:import [java.io File]
+           [java.net InetAddress ServerSocket]))
 
 (deftest parse-port-from-output-test
   ;; Test parsing nREPL port numbers from various output formats
@@ -169,3 +170,73 @@
         ;; setup-process-cleanup has try-catch around destroyOnExit for Java
         ;; version compatibility
         (is (some? mock-process))))))
+
+(deftest port-reachable?-test
+  (testing "port-reachable?"
+    (testing "returns true when something is listening on the port"
+      (let [server (ServerSocket. 0 0 (InetAddress/getLoopbackAddress))
+            port (.getLocalPort server)]
+        (try
+          (is (true? (launcher/port-reachable? "localhost" port 500)))
+          (finally
+            (.close server)))))
+
+    (testing "returns false when no listener exists"
+      ;; Grab an ephemeral port, immediately release it, and probe.
+      ;; The port may be reused by another process but typically isn't
+      ;; in a tight window like this.
+      (let [server (ServerSocket. 0 0 (InetAddress/getLoopbackAddress))
+            port (.getLocalPort server)]
+        (.close server)
+        (is (false? (launcher/port-reachable? "localhost" port 500)))))))
+
+(deftest maybe-start-fallback-nrepl-test
+  (testing "maybe-start-fallback-nrepl"
+    (testing "returns args unchanged when :fallback-nrepl is unset"
+      (let [args {:port 7888}]
+        (is (= args (launcher/maybe-start-fallback-nrepl args)))))
+
+    (testing "returns args unchanged when :fallback-nrepl is false"
+      (let [args {:port 7888 :fallback-nrepl false}]
+        (is (= args (launcher/maybe-start-fallback-nrepl args)))))
+
+    (testing "attaches to an existing reachable nREPL without spawning"
+      (let [server (ServerSocket. 0 0 (InetAddress/getLoopbackAddress))
+            port (.getLocalPort server)]
+        (try
+          (let [args {:port port :fallback-nrepl true
+                      :fallback-nrepl-cmd ["should-not-run"]
+                      :start-nrepl-cmd ["should-also-not-run"]}
+                result (launcher/maybe-start-fallback-nrepl args)]
+            (is (= port (:port result)) "uses the reachable port")
+            (is (nil? (:nrepl-process result)) "did not spawn a process")
+            ;; Fallback-mode keys and :start-nrepl-cmd are dropped so the
+            ;; downstream pipeline doesn't double-process.
+            (is (nil? (:fallback-nrepl result)))
+            (is (nil? (:fallback-nrepl-cmd result)))
+            (is (nil? (:fallback-nrepl-dir result)))
+            (is (nil? (:start-nrepl-cmd result))))
+          (finally
+            (.close server)))))))
+
+(deftest default-fallback-nrepl-cmd-test
+  (testing "default-fallback-nrepl-cmd"
+    (testing "includes clojure, -Sdeps, and nrepl.cmdline"
+      (let [cmd (launcher/default-fallback-nrepl-cmd)]
+        (is (= "clojure" (first cmd)))
+        (is (some #{"-Sdeps"} cmd))
+        (is (some #{"nrepl.cmdline"} cmd))))
+
+    (testing "embeds the runtime nREPL version, not a hardcoded one"
+      (let [cmd (launcher/default-fallback-nrepl-cmd)
+            sdeps-arg (->> cmd
+                           (drop-while #(not= "-Sdeps" %))
+                           second)]
+        (is (some? sdeps-arg))
+        ;; Should mention the nrepl coordinate using the loaded version.
+        (is (re-find (re-pattern
+                      (str "nrepl/nrepl\\s*\\{:mvn/version\\s*\""
+                           (java.util.regex.Pattern/quote
+                            (:version-string @(requiring-resolve 'nrepl.version/version)))
+                           "\""))
+                     sdeps-arg))))))

--- a/test/clojure_mcp/nrepl_launcher_test.clj
+++ b/test/clojure_mcp/nrepl_launcher_test.clj
@@ -217,7 +217,21 @@
             (is (nil? (:fallback-nrepl-dir result)))
             (is (nil? (:start-nrepl-cmd result))))
           (finally
-            (.close server)))))))
+            (.close server)))))
+
+    (testing "fallback spawn overrides remote :host with localhost"
+      ;; Without this override, the downstream connect would target
+      ;; the user-supplied remote host on the spawned ephemeral port,
+      ;; which would fail.
+      (with-redefs [launcher/port-reachable? (constantly false)
+                    launcher/start-nrepl-process
+                    (fn [_] {:port 54321 :process :fake-process})]
+        (let [args {:host "remote.example" :port 7888 :fallback-nrepl true}
+              result (launcher/maybe-start-fallback-nrepl args)]
+          (is (= "localhost" (:host result))
+              "remote :host is replaced with localhost after spawn")
+          (is (= 54321 (:port result)) "uses the spawned port")
+          (is (= :fake-process (:nrepl-process result))))))))
 
 (deftest default-fallback-nrepl-cmd-test
   (testing "default-fallback-nrepl-cmd"


### PR DESCRIPTION
I am often without an nrepl session running, either because I'm not currently editing code, or because my repl is in a terminal. Consequently, Claude is often complaining that it can't connect to this MCP service.

This PR introduces an opt-in flag that lets clojure-mcp survive when no editor-managed nREPL is running. When :fallback-nrepl is true, the launcher first probes :port (via a short TCP socket attempt) and attaches if reachable; if not, it spawns a local nREPL on an ephemeral port and connects to that. The configured :port is never squatted on, so a later editor session can still claim it.

The default fallback command is built from clojure-mcp's own nREPL dependency (via nrepl.version), so no version is hardcoded in source. It runs through `clojure -Sdeps ... -M -m nrepl.cmdline`, which still merges in the user's ~/.clojure/deps.edn -- so globally-available libraries like Criterium remain on the spawned REPL's classpath.

Companion options:
  :fallback-nrepl-cmd  override default command (vector of strings)
  :fallback-nrepl-dir  working dir; default :project-dir or $HOME

Default behavior is unchanged -- the flag is fully opt-in. Primary motivation is making Claude Desktop usable when the user hasn't started a project REPL: today it fails with "Server disconnected" the moment nREPL connection setup throws.

**NOTE:** This is Claude-generated code. I have reviewed it, and it runs correctly locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in fallback nREPL mode: probes the configured host/port and, if unreachable (or port omitted), spawns a local nREPL on an ephemeral port
  * Added configuration options: `:fallback-nrepl`, `:fallback-nrepl-cmd`, and `:fallback-nrepl-dir` to control the fallback command and working directory
* **Breaking Changes**
  * Replaced the legacy HTTP+SSE transport with MCP Streamable HTTP (single `/mcp` endpoint with POST/GET/DELETE streaming and session control)
* **Tests**
  * Added coverage for fallback reachability and fallback spawning/command construction
* **Documentation**
  * Updated CLI/usage documentation for the new options and transport behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->