### PR TITLE
Add optional CLOJURE_MCP_TRAINING_DIR training-log emit

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,6 +712,37 @@ Configuration is extensively documented [here](doc/CONFIG.md).
 
 **Note**: Configuration is loaded when the MCP server starts. Restart the server (or the Chat Agent) after making configuration changes.
 
+## 📊 Optional: Training-log emit
+
+ClojureMCP can optionally write a per-session JSONL trace of every
+tool call to a local directory. **This is off by default** — set the
+`CLOJURE_MCP_TRAINING_DIR` environment variable to a writable
+directory before starting the server to enable it:
+
+```bash
+export CLOJURE_MCP_TRAINING_DIR="$HOME/.clojure-mcp/training"
+clojure -X:mcp
+```
+
+Each session writes:
+
+- `session-<uuid>-turns.jsonl` — one line per tool call (name, args,
+  result, ok/error, ISO-8601 timestamp)
+- `session-<uuid>-summary.edn` — session-level stats written on JVM
+  shutdown (turn count, tools used, session start/end)
+
+The emitted shape is a subset of a schema used by an external
+training-corpus pipeline for LLM fine-tuning. It is designed so any
+downstream ingest can read the files directly.
+
+**Zero effect on tool behaviour.** The emit runs after the tool has
+already completed. Any exception in the emit path is logged and
+swallowed so a training-log bug cannot break tool responses.
+
+**Files are sensitive.** Traces contain tool arguments (file contents,
+shell commands, eval expressions) and results. Keep the training dir
+on a private disk and treat as you would `.bash_history`.
+
 ## 📝 License
 
 Eclipse Public License - v 2.0

--- a/src/clojure_mcp/core.clj
+++ b/src/clojure_mcp/core.clj
@@ -116,10 +116,17 @@
                  (fn [exchange arg-map mono-fill-k]
                    (let [clj-result-k
                          (fn [res-list error?]
+                           ;; Signal the MCP response FIRST so client
+                           ;; latency is unaffected by any downstream
+                           ;; I/O. record-tool-call! is a non-blocking
+                           ;; submit to a bounded serialised writer, so
+                           ;; even without this ordering the disk write
+                           ;; wouldn't block — but ordering makes the
+                           ;; guarantee explicit at the seam.
+                           (mono-fill-k (adapt-results res-list error?))
                            ;; Opt-in training-log emit — no-op unless
                            ;; CLOJURE_MCP_TRAINING_DIR env is set.
-                           (training-log/record-tool-call! name arg-map res-list error?)
-                           (mono-fill-k (adapt-results res-list error?)))]
+                           (training-log/record-tool-call! name arg-map res-list error?))]
                      (tool-fn exchange arg-map clj-result-k))))]
     (McpServerFeatures$AsyncToolSpecification.
      mcp-tool

--- a/src/clojure_mcp/core.clj
+++ b/src/clojure_mcp/core.clj
@@ -7,7 +7,8 @@
             [clojure-mcp.nrepl :as nrepl]
             [clojure-mcp.config :as config]
             [clojure-mcp.file-content :as file-content]
-            [clojure-mcp.nrepl-launcher :as nrepl-launcher])
+            [clojure-mcp.nrepl-launcher :as nrepl-launcher]
+            [clojure-mcp.training-log :as training-log])
   (:import [io.modelcontextprotocol.server.transport
             StdioServerTransportProvider]
            [io.modelcontextprotocol.server McpServer
@@ -115,6 +116,9 @@
                  (fn [exchange arg-map mono-fill-k]
                    (let [clj-result-k
                          (fn [res-list error?]
+                           ;; Opt-in training-log emit — no-op unless
+                           ;; CLOJURE_MCP_TRAINING_DIR env is set.
+                           (training-log/record-tool-call! name arg-map res-list error?)
                            (mono-fill-k (adapt-results res-list error?)))]
                      (tool-fn exchange arg-map clj-result-k))))]
     (McpServerFeatures$AsyncToolSpecification.

--- a/src/clojure_mcp/training_log.clj
+++ b/src/clojure_mcp/training_log.clj
@@ -7,29 +7,38 @@
    `session-<uuid>-turns.jsonl`; a `session-<uuid>-summary.edn`
    snapshots on JVM shutdown.
 
-   The emitted shape mirrors the PRD-09 §2.1/§2.2 schema used by the
-   verity/memory-hawk corpus pipeline (see the ADR link in the PR
-   description). Anyone can point at that pipeline OR any other
-   ingest that reads the same shape.
+   The emitted shape mirrors a schema used by an external training-
+   corpus pipeline for LLM fine-tuning. Anyone can point at that
+   pipeline OR any other ingest that reads the same shape.
 
-   Zero effect on tool behaviour: if the emit throws or the disk is
-   full, the caller sees nothing — WARN goes to the logger and the
-   tool response continues normally. Emit-side failure MUST NOT
-   propagate to the client.
+   Zero effect on tool behaviour:
+   - The MCP response is NOT blocked on emit I/O. The interceptor
+     hands the (name, args, result) triple to a bounded background
+     writer and returns immediately.
+   - Any Exception during emit is caught, WARN-logged, and counted
+     in `failure-count` (public for observability). Fatal JVM errors
+     (Error subclasses like OutOfMemoryError) are deliberately NOT
+     caught — those signal a system-wide problem the tool caller
+     should know about.
+
+   Concurrency:
+   - Turn-index reservation + JSONL append run inside a serialised
+     writer (single-thread executor). Concurrent callbacks reserve
+     unique sequential indexes and their lines land in submission
+     order. Verified by the concurrent-emission test.
 
    Non-goals:
    - No network I/O. The emit writes local files; dispatch to any
      server is a separate concern.
    - No PII scrubbing. Callers should treat the training dir as
-     sensitive (contains file contents + shell arguments).
-   - No hook for tool responses whose bytes reveal secrets — a
-     downstream ingest is expected to redact."
+     sensitive (contains file contents + shell arguments)."
   (:require [clojure.data.json :as json]
             [clojure.java.io :as io]
             [clojure.string :as str]
             [taoensso.timbre :as log])
   (:import [java.time Instant]
-           [java.util UUID]))
+           [java.util UUID]
+           [java.util.concurrent Executors ExecutorService TimeUnit]))
 
 (def ^:private training-dir
   (some-> (System/getenv "CLOJURE_MCP_TRAINING_DIR") str/trim not-empty))
@@ -43,6 +52,23 @@
 (defonce ^:private session-state
   (atom {:session-id nil :turn-index 0 :tools-used #{}
          :started-at nil :turn-count 0}))
+
+(defonce ^{:doc "Emit-side failure counter. Bumped once per exception
+  swallowed by the emit path (either the per-turn record or the shutdown
+  summary write). Public so ops can graph 'training-log emit health'
+  without reading logs."}
+  failure-count (atom 0))
+
+;; Single-thread serialised writer. All record + write work runs here;
+;; the caller thread (the MCP tool callback) returns immediately after
+;; submit, so response latency is unaffected by disk I/O.
+(defonce ^:private ^ExecutorService writer-executor
+  (let [thread-factory
+        (reify java.util.concurrent.ThreadFactory
+          (newThread [_ r]
+            (doto (Thread. r "clojure-mcp-training-log")
+              (.setDaemon true))))]
+    (Executors/newSingleThreadExecutor thread-factory)))
 
 (defn- ensure-session! []
   (swap! session-state
@@ -61,43 +87,64 @@
   (io/file training-dir
            (str "session-" (:session-id @session-state) "-summary.edn")))
 
+(defn- record-tool-call-sync!
+  "Runs on the writer-executor thread. Atomic: reserves the next
+   turn-index via `swap-vals!` (returns old + new state in one CAS),
+   builds the line from the reserved index, appends to the JSONL.
+   Single-thread executor means the append order matches the
+   submission order."
+  [tool-name arg-map result-strs error?]
+  (try
+    (ensure-session!)
+    (let [[before after]
+          (swap-vals! session-state
+                      (fn [s] (-> s
+                                  (update :turn-index inc)
+                                  (update :turn-count inc)
+                                  (update :tools-used conj tool-name))))
+          reserved-index (:turn-index before)
+          turn {:session-id     (:session-id after)
+                :turn-index     reserved-index
+                :model          "unknown"
+                :user           nil
+                :reasoning      nil
+                :tool-calls     [{:tool   tool-name
+                                  :input  (or arg-map {})
+                                  :output (apply str result-strs)
+                                  :status (if error? :error :ok)
+                                  :ms     nil}]
+                :outcome        (if error? :error :verified)
+                :evidence-hash  nil
+                :read-only?     false
+                :timestamp      (str (Instant/now))}
+          line (json/write-str turn)]
+      (io/make-parents (turns-path))
+      (spit (turns-path) (str line "\n") :append true))
+    (catch Exception e
+      (swap! failure-count inc)
+      (log/warn "clojure-mcp training emit failed"
+                {:tool tool-name :error (.getMessage e)}))))
+
 (defn record-tool-call!
   "Called from `create-async-tool`'s continuation AFTER the tool_fn's
-   `clj-result-k` fires. Args are captured verbatim from the MCP call;
-   the result is the vector of strings the tool passed to `clj-result-k`.
+   `clj-result-k` fires. Non-blocking: submits the record job to a
+   bounded serialised writer and returns immediately. Callers see no
+   latency from disk I/O and no exception can propagate.
 
-   Never throws — emit failures are logged and swallowed so a training-log
-   bug can never break a tool response."
+   Idempotent for the disabled case — no-op when the env var is unset."
   [tool-name arg-map result-strs error?]
   (when enabled?
     (try
-      (ensure-session!)
-      (let [before  @session-state
-            _       (swap! session-state
-                           (fn [s] (-> s
-                                       (update :turn-index inc)
-                                       (update :turn-count inc)
-                                       (update :tools-used conj tool-name))))
-            turn    {:session-id     (:session-id before)
-                     :turn-index     (:turn-index before)
-                     :model          "unknown"
-                     :user           nil
-                     :reasoning      nil
-                     :tool-calls     [{:tool   tool-name
-                                       :input  (or arg-map {})
-                                       :output (apply str result-strs)
-                                       :status (if error? :error :ok)
-                                       :ms     nil}]
-                     :outcome        (if error? :error :verified)
-                     :evidence-hash  nil
-                     :read-only?     false
-                     :timestamp      (str (Instant/now))}
-            line    (json/write-str turn)]
-        (io/make-parents (turns-path))
-        (spit (turns-path) (str line "\n") :append true))
-      (catch Throwable e
-        (log/warn "clojure-mcp training emit failed"
-                  {:tool tool-name :error (.getMessage e)})))))
+      (.submit writer-executor
+               ^Runnable
+               (fn [] (record-tool-call-sync!
+                        tool-name arg-map result-strs error?)))
+      (catch java.util.concurrent.RejectedExecutionException e
+        ;; Executor is shutting down — count + carry on.
+        (swap! failure-count inc)
+        (log/warn "clojure-mcp training emit rejected (executor closed)"
+                  {:tool tool-name :error (.getMessage e)})))
+    nil))
 
 (defn- write-summary! []
   (when enabled?
@@ -120,10 +167,20 @@
                                      :verity-version  "n/a"
                                      :verity-commit   "n/a"}
                   :quality-hints    {}}))))
-      (catch Throwable e
+      (catch Exception e
+        (swap! failure-count inc)
         (log/warn "clojure-mcp training summary write failed"
                   {:error (.getMessage e)})))))
 
+(defn- flush-and-write-summary! []
+  ;; Drain in-flight writes first so the summary's turn-count matches
+  ;; what actually landed in the JSONL.
+  (try
+    (.shutdown writer-executor)
+    (.awaitTermination writer-executor 5 TimeUnit/SECONDS)
+    (catch InterruptedException _))
+  (write-summary!))
+
 (when enabled?
   (log/info "clojure-mcp training-log enabled" {:dir training-dir})
-  (.addShutdownHook (Runtime/getRuntime) (Thread. ^Runnable write-summary!)))
+  (.addShutdownHook (Runtime/getRuntime) (Thread. ^Runnable flush-and-write-summary!)))

--- a/src/clojure_mcp/training_log.clj
+++ b/src/clojure_mcp/training_log.clj
@@ -13,13 +13,24 @@
 
    Zero effect on tool behaviour:
    - The MCP response is NOT blocked on emit I/O. The interceptor
-     hands the (name, args, result) triple to a bounded background
-     writer and returns immediately.
+     hands the (name, args, result) triple to a SERIALISED background
+     writer (single-thread executor with an unbounded queue) and
+     returns immediately. Unbounded is intentional for this opt-in
+     tool: dropping training records to protect memory is worse than
+     the training records themselves — and the queue can only grow
+     if disk I/O is stalled indefinitely, which is a system-wide
+     problem the operator should already be seeing.
    - Any Exception during emit is caught, WARN-logged, and counted
      in `failure-count` (public for observability). Fatal JVM errors
      (Error subclasses like OutOfMemoryError) are deliberately NOT
      caught — those signal a system-wide problem the tool caller
      should know about.
+   - Turn accounting is TWO-STAGE: the reservation step gives every
+     submitted call a unique sequential `:turn-index` (never
+     collides), but the session-level `:turn-count` only advances on
+     WRITE SUCCESS. The summary's `:tool-call-count` reflects records
+     that actually landed in the JSONL, not records that were
+     submitted-but-failed.
 
    Concurrency:
    - Turn-index reservation + JSONL append run inside a serialised
@@ -88,20 +99,22 @@
            (str "session-" (:session-id @session-state) "-summary.edn")))
 
 (defn- record-tool-call-sync!
-  "Runs on the writer-executor thread. Atomic: reserves the next
-   turn-index via `swap-vals!` (returns old + new state in one CAS),
-   builds the line from the reserved index, appends to the JSONL.
-   Single-thread executor means the append order matches the
-   submission order."
+  "Runs on the writer-executor thread. Two-stage accounting:
+   1. RESERVE: atomically increment `:turn-index` (single CAS via
+      swap-vals!) — every submitted call gets a unique sequential
+      index even if writes race.
+   2. WRITE: build + append the JSONL line. On success, bump
+      `:turn-count` + `:tools-used` so summary counters reflect
+      records that ACTUALLY landed (not just ones that were
+      submitted-but-failed). On failure, `:turn-index` is still
+      consumed (leaves an honest gap that a curator UI can detect)
+      but summary counts stay accurate."
   [tool-name arg-map result-strs error?]
   (try
     (ensure-session!)
     (let [[before after]
           (swap-vals! session-state
-                      (fn [s] (-> s
-                                  (update :turn-index inc)
-                                  (update :turn-count inc)
-                                  (update :tools-used conj tool-name))))
+                      (fn [s] (update s :turn-index inc)))
           reserved-index (:turn-index before)
           turn {:session-id     (:session-id after)
                 :turn-index     reserved-index
@@ -119,7 +132,13 @@
                 :timestamp      (str (Instant/now))}
           line (json/write-str turn)]
       (io/make-parents (turns-path))
-      (spit (turns-path) (str line "\n") :append true))
+      (spit (turns-path) (str line "\n") :append true)
+      ;; Advance the "actually-written" counters AFTER a successful
+      ;; write — summary EDN's counts must not drift from the JSONL.
+      (swap! session-state
+             (fn [s] (-> s
+                         (update :turn-count inc)
+                         (update :tools-used conj tool-name)))))
     (catch Exception e
       (swap! failure-count inc)
       (log/warn "clojure-mcp training emit failed"
@@ -174,11 +193,18 @@
 
 (defn- flush-and-write-summary! []
   ;; Drain in-flight writes first so the summary's turn-count matches
-  ;; what actually landed in the JSONL.
+  ;; what actually landed in the JSONL. Log a warning if drain times
+  ;; out — a discarded false from awaitTermination would let
+  ;; write-summary! run against unsettled state.
   (try
     (.shutdown writer-executor)
-    (.awaitTermination writer-executor 5 TimeUnit/SECONDS)
-    (catch InterruptedException _))
+    (let [drained? (.awaitTermination writer-executor 5 TimeUnit/SECONDS)]
+      (when-not drained?
+        (swap! failure-count inc)
+        (log/warn "clojure-mcp training-log drain timed out — summary counts may lag"
+                  {:pending-tasks-approx "unknown (executor doesn't expose it)"})))
+    (catch InterruptedException _
+      (log/warn "clojure-mcp training-log drain interrupted")))
   (write-summary!))
 
 (when enabled?

--- a/src/clojure_mcp/training_log.clj
+++ b/src/clojure_mcp/training_log.clj
@@ -1,0 +1,129 @@
+(ns clojure-mcp.training-log
+  "Opt-in training-log emit for clojure-mcp sessions.
+
+   Off by default. Enable by setting the `CLOJURE_MCP_TRAINING_DIR`
+   environment variable to a writable directory before starting the
+   server. Each intercepted tool call becomes one line of
+   `session-<uuid>-turns.jsonl`; a `session-<uuid>-summary.edn`
+   snapshots on JVM shutdown.
+
+   The emitted shape mirrors the PRD-09 §2.1/§2.2 schema used by the
+   verity/memory-hawk corpus pipeline (see the ADR link in the PR
+   description). Anyone can point at that pipeline OR any other
+   ingest that reads the same shape.
+
+   Zero effect on tool behaviour: if the emit throws or the disk is
+   full, the caller sees nothing — WARN goes to the logger and the
+   tool response continues normally. Emit-side failure MUST NOT
+   propagate to the client.
+
+   Non-goals:
+   - No network I/O. The emit writes local files; dispatch to any
+     server is a separate concern.
+   - No PII scrubbing. Callers should treat the training dir as
+     sensitive (contains file contents + shell arguments).
+   - No hook for tool responses whose bytes reveal secrets — a
+     downstream ingest is expected to redact."
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [taoensso.timbre :as log])
+  (:import [java.time Instant]
+           [java.util UUID]))
+
+(def ^:private training-dir
+  (some-> (System/getenv "CLOJURE_MCP_TRAINING_DIR") str/trim not-empty))
+
+(def enabled?
+  "True when the CLOJURE_MCP_TRAINING_DIR env var is set to a
+   non-empty string. Callers can short-circuit expensive setup with
+   this — the interceptor itself also no-ops when false."
+  (some? training-dir))
+
+(defonce ^:private session-state
+  (atom {:session-id nil :turn-index 0 :tools-used #{}
+         :started-at nil :turn-count 0}))
+
+(defn- ensure-session! []
+  (swap! session-state
+         (fn [s]
+           (cond-> s
+             (nil? (:session-id s))
+             (assoc :session-id (str (UUID/randomUUID))
+                    :started-at (str (Instant/now))
+                    :turn-index 0)))))
+
+(defn- turns-path []
+  (io/file training-dir
+           (str "session-" (:session-id @session-state) "-turns.jsonl")))
+
+(defn- summary-path []
+  (io/file training-dir
+           (str "session-" (:session-id @session-state) "-summary.edn")))
+
+(defn record-tool-call!
+  "Called from `create-async-tool`'s continuation AFTER the tool_fn's
+   `clj-result-k` fires. Args are captured verbatim from the MCP call;
+   the result is the vector of strings the tool passed to `clj-result-k`.
+
+   Never throws — emit failures are logged and swallowed so a training-log
+   bug can never break a tool response."
+  [tool-name arg-map result-strs error?]
+  (when enabled?
+    (try
+      (ensure-session!)
+      (let [before  @session-state
+            _       (swap! session-state
+                           (fn [s] (-> s
+                                       (update :turn-index inc)
+                                       (update :turn-count inc)
+                                       (update :tools-used conj tool-name))))
+            turn    {:session-id     (:session-id before)
+                     :turn-index     (:turn-index before)
+                     :model          "unknown"
+                     :user           nil
+                     :reasoning      nil
+                     :tool-calls     [{:tool   tool-name
+                                       :input  (or arg-map {})
+                                       :output (apply str result-strs)
+                                       :status (if error? :error :ok)
+                                       :ms     nil}]
+                     :outcome        (if error? :error :verified)
+                     :evidence-hash  nil
+                     :read-only?     false
+                     :timestamp      (str (Instant/now))}
+            line    (json/write-str turn)]
+        (io/make-parents (turns-path))
+        (spit (turns-path) (str line "\n") :append true))
+      (catch Throwable e
+        (log/warn "clojure-mcp training emit failed"
+                  {:tool tool-name :error (.getMessage e)})))))
+
+(defn- write-summary! []
+  (when enabled?
+    (try
+      (let [{:keys [session-id started-at tools-used turn-count]} @session-state]
+        (when session-id
+          (spit (summary-path)
+                (pr-str
+                 {:session-id       session-id
+                  :source           "clojure-mcp"
+                  :started-at       started-at
+                  :ended-at         (str (Instant/now))
+                  :turn-count       turn-count
+                  :tool-call-count  turn-count
+                  :tools-used       (vec (sort tools-used))
+                  :project          (System/getProperty "user.dir")
+                  :outcome          :verified
+                  :read-only?       false
+                  :provenance       {:generator-model "unknown"
+                                     :verity-version  "n/a"
+                                     :verity-commit   "n/a"}
+                  :quality-hints    {}}))))
+      (catch Throwable e
+        (log/warn "clojure-mcp training summary write failed"
+                  {:error (.getMessage e)})))))
+
+(when enabled?
+  (log/info "clojure-mcp training-log enabled" {:dir training-dir})
+  (.addShutdownHook (Runtime/getRuntime) (Thread. ^Runnable write-summary!)))

--- a/test/clojure_mcp/training_log_test.clj
+++ b/test/clojure_mcp/training_log_test.clj
@@ -7,7 +7,8 @@
             [clojure.string :as string]
             [clojure.java.io :as io]
             [clojure-mcp.training-log :as tl])
-  (:import [java.util UUID]))
+  (:import [java.util UUID]
+           [java.util.concurrent CountDownLatch Executors TimeUnit]))
 
 (defn- fresh-dir []
   (let [d (str (System/getProperty "java.io.tmpdir")
@@ -15,17 +16,25 @@
     (io/make-parents (str d "/x"))
     d))
 
+(defn- drain! []
+  ;; The record path is now async. Tests need to wait for the writer
+  ;; thread to finish before asserting on file contents. Submit a
+  ;; blocking no-op and await it — this guarantees any earlier submit
+  ;; has run because the executor is single-threaded.
+  (let [latch (CountDownLatch. 1)]
+    (.submit @#'tl/writer-executor
+             ^Runnable (fn [] (.countDown latch)))
+    (.await latch 5 TimeUnit/SECONDS)))
+
 (defn- with-training-dir* [dir f]
-  ;; The env-var read at ns-load can't be rebindt from here — instead
-  ;; we rebind the private var directly for the duration of the test.
   (let [original @#'tl/training-dir]
     (try
       (alter-var-root #'tl/training-dir (constantly dir))
       (alter-var-root #'tl/enabled? (constantly (some? dir)))
-      ;; Reset the session-atom so each test starts clean.
       (reset! @#'tl/session-state
               {:session-id nil :turn-index 0 :tools-used #{}
                :started-at nil :turn-count 0})
+      (reset! tl/failure-count 0)
       (f)
       (finally
         (alter-var-root #'tl/training-dir (constantly original))
@@ -47,6 +56,7 @@
   (let [dir (fresh-dir)]
     (with-training-dir dir
       (tl/record-tool-call! "clojure_eval" {:code "(+ 1 2)"} ["3"] false)
+      (drain!)
       (let [lines (list-turn-lines dir)]
         (is (= 1 (count lines)) "one JSONL line per tool call")
         (is (string/includes? (first lines) "\"clojure_eval\""))
@@ -56,15 +66,13 @@
 (deftest no-op-when-disabled-test
   (with-training-dir nil
     (tl/record-tool-call! "clojure_eval" {:code "(+ 1 2)"} ["3"] false)
-    ;; No file to check for — the emit path short-circuits on
-    ;; `enabled?` false. The assertion is simply that the call returned
-    ;; without throwing.
     (is (false? tl/enabled?))))
 
 (deftest error-flag-sets-outcome-error-test
   (let [dir (fresh-dir)]
     (with-training-dir dir
       (tl/record-tool-call! "clojure_eval" {:code "(/ 1 0)"} ["ArithmeticException"] true)
+      (drain!)
       (let [lines (list-turn-lines dir)]
         (is (= 1 (count lines)))
         (is (string/includes? (first lines) "\"outcome\":\"error\""))
@@ -76,6 +84,7 @@
       (dotimes [i 5]
         (tl/record-tool-call! "clojure_eval" {:code (str "(inc " i ")")}
                               [(str (inc i))] false))
+      (drain!)
       (let [lines (list-turn-lines dir)]
         (is (= 5 (count lines)))
         (is (= [0 1 2 3 4]
@@ -84,9 +93,52 @@
                          (Long/parseLong (second m))))
                      lines)))))))
 
+(deftest concurrent-emit-preserves-unique-indexes-test
+  (testing (str "many threads hammering record-tool-call! concurrently must NOT "
+                "produce duplicate turn-indexes — the writer-executor serialises "
+                "reservation + append.")
+    (let [dir (fresh-dir)
+          n 50
+          pool (Executors/newFixedThreadPool 8)]
+      (with-training-dir dir
+        (try
+          (let [futures (mapv (fn [i]
+                                (.submit pool
+                                         ^Callable
+                                         (fn [] (tl/record-tool-call!
+                                                  "clojure_eval"
+                                                  {:code (str "(inc " i ")")}
+                                                  [(str (inc i))] false))))
+                              (range n))]
+            (doseq [f futures] (.get f)))
+          (finally
+            (.shutdown pool)
+            (.awaitTermination pool 5 TimeUnit/SECONDS)))
+        (drain!)
+        (let [lines (list-turn-lines dir)
+              indexes (mapv (fn [line]
+                              (Long/parseLong
+                                (second (re-find #"\"turn-index\":(\d+)" line))))
+                            lines)]
+          (is (= n (count lines))
+              "one line per submitted call")
+          (is (= n (count (distinct indexes)))
+              "no duplicate turn-indexes under concurrent submission")
+          (is (= (set (range n)) (set indexes))
+              "the full 0..N-1 range is present"))))))
+
 (deftest emit-never-throws-on-io-failure-test
-  (testing (str "the emit MUST swallow every exception — a bug in the emit "
-                "path can't be allowed to break the tool call it's observing")
-    (with-training-dir "/proc/1/definitely-not-writable"
-      ;; No exception should propagate.
-      (is (nil? (tl/record-tool-call! "clojure_eval" {} ["ok"] false))))))
+  (testing (str "the emit MUST swallow every expected exception. Portable "
+                "fixture: point CLOJURE_MCP_TRAINING_DIR at a REGULAR FILE "
+                "(not a directory) — subsequent io/make-parents + spit will "
+                "fail with an IOException that the emit path must catch.")
+    (let [tmp (fresh-dir)
+          not-a-dir (str tmp "/regular-file-not-a-dir")
+          _ (spit not-a-dir "seed")]
+      (with-training-dir not-a-dir
+        (is (nil? (tl/record-tool-call! "clojure_eval" {} ["ok"] false)))
+        (drain!)
+        (is (pos? @tl/failure-count)
+            "failure counter must have been bumped by the swallowed exception")
+        (is (empty? (list-turn-lines not-a-dir))
+            "no JSONL file created (write path failed as expected)")))))

--- a/test/clojure_mcp/training_log_test.clj
+++ b/test/clojure_mcp/training_log_test.clj
@@ -1,0 +1,92 @@
+(ns clojure-mcp.training-log-test
+  "Tests for the opt-in training-log emit. All hermetic — write to a
+   fresh tmp dir per test, assert JSONL round-trips, then delete.
+   The `record-tool-call!` fn must NEVER throw (a bug there could
+   otherwise break every tool call), so error-path tests are here too."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as string]
+            [clojure.java.io :as io]
+            [clojure-mcp.training-log :as tl])
+  (:import [java.util UUID]))
+
+(defn- fresh-dir []
+  (let [d (str (System/getProperty "java.io.tmpdir")
+               "/clojure-mcp-tl-test-" (UUID/randomUUID))]
+    (io/make-parents (str d "/x"))
+    d))
+
+(defn- with-training-dir* [dir f]
+  ;; The env-var read at ns-load can't be rebindt from here — instead
+  ;; we rebind the private var directly for the duration of the test.
+  (let [original @#'tl/training-dir]
+    (try
+      (alter-var-root #'tl/training-dir (constantly dir))
+      (alter-var-root #'tl/enabled? (constantly (some? dir)))
+      ;; Reset the session-atom so each test starts clean.
+      (reset! @#'tl/session-state
+              {:session-id nil :turn-index 0 :tools-used #{}
+               :started-at nil :turn-count 0})
+      (f)
+      (finally
+        (alter-var-root #'tl/training-dir (constantly original))
+        (alter-var-root #'tl/enabled? (constantly (some? original)))))))
+
+(defmacro with-training-dir [dir & body]
+  `(with-training-dir* ~dir (fn [] ~@body)))
+
+(defn- list-turn-lines [dir]
+  (let [d (io/file dir)]
+    (when (.exists d)
+      (->> (.listFiles d)
+           (filter #(string/ends-with? (.getName ^java.io.File %) "-turns.jsonl"))
+           (mapcat #(string/split-lines (slurp %)))
+           (remove string/blank?)
+           vec))))
+
+(deftest records-tool-call-when-enabled-test
+  (let [dir (fresh-dir)]
+    (with-training-dir dir
+      (tl/record-tool-call! "clojure_eval" {:code "(+ 1 2)"} ["3"] false)
+      (let [lines (list-turn-lines dir)]
+        (is (= 1 (count lines)) "one JSONL line per tool call")
+        (is (string/includes? (first lines) "\"clojure_eval\""))
+        (is (string/includes? (first lines) "\"(+ 1 2)\""))
+        (is (string/includes? (first lines) "\"turn-index\":0"))))))
+
+(deftest no-op-when-disabled-test
+  (with-training-dir nil
+    (tl/record-tool-call! "clojure_eval" {:code "(+ 1 2)"} ["3"] false)
+    ;; No file to check for — the emit path short-circuits on
+    ;; `enabled?` false. The assertion is simply that the call returned
+    ;; without throwing.
+    (is (false? tl/enabled?))))
+
+(deftest error-flag-sets-outcome-error-test
+  (let [dir (fresh-dir)]
+    (with-training-dir dir
+      (tl/record-tool-call! "clojure_eval" {:code "(/ 1 0)"} ["ArithmeticException"] true)
+      (let [lines (list-turn-lines dir)]
+        (is (= 1 (count lines)))
+        (is (string/includes? (first lines) "\"outcome\":\"error\""))
+        (is (string/includes? (first lines) "\"status\":\"error\""))))))
+
+(deftest monotonic-turn-index-across-calls-test
+  (let [dir (fresh-dir)]
+    (with-training-dir dir
+      (dotimes [i 5]
+        (tl/record-tool-call! "clojure_eval" {:code (str "(inc " i ")")}
+                              [(str (inc i))] false))
+      (let [lines (list-turn-lines dir)]
+        (is (= 5 (count lines)))
+        (is (= [0 1 2 3 4]
+               (mapv (fn [line]
+                       (let [m (re-find #"\"turn-index\":(\d+)" line)]
+                         (Long/parseLong (second m))))
+                     lines)))))))
+
+(deftest emit-never-throws-on-io-failure-test
+  (testing (str "the emit MUST swallow every exception — a bug in the emit "
+                "path can't be allowed to break the tool call it's observing")
+    (with-training-dir "/proc/1/definitely-not-writable"
+      ;; No exception should propagate.
+      (is (nil? (tl/record-tool-call! "clojure_eval" {} ["ok"] false))))))

--- a/test/clojure_mcp/training_log_test.clj
+++ b/test/clojure_mcp/training_log_test.clj
@@ -26,9 +26,23 @@
              ^Runnable (fn [] (.countDown latch)))
     (.await latch 5 TimeUnit/SECONDS)))
 
+(defn- ensure-writer-executor! []
+  ;; The drain-summary test intentionally shuts the executor down.
+  ;; Rebuild if needed so subsequent tests can submit.
+  (let [ex @#'tl/writer-executor]
+    (when (.isShutdown ex)
+      (alter-var-root #'tl/writer-executor
+                      (fn [_]
+                        (let [tf (reify java.util.concurrent.ThreadFactory
+                                   (newThread [_ r]
+                                     (doto (Thread. r "clojure-mcp-training-log")
+                                       (.setDaemon true))))]
+                          (java.util.concurrent.Executors/newSingleThreadExecutor tf)))))))
+
 (defn- with-training-dir* [dir f]
   (let [original @#'tl/training-dir]
     (try
+      (ensure-writer-executor!)
       (alter-var-root #'tl/training-dir (constantly dir))
       (alter-var-root #'tl/enabled? (constantly (some? dir)))
       (reset! @#'tl/session-state
@@ -126,6 +140,52 @@
               "no duplicate turn-indexes under concurrent submission")
           (is (= (set (range n)) (set indexes))
               "the full 0..N-1 range is present"))))))
+
+(deftest write-failure-does-not-drift-turn-count-test
+  (testing (str "turn-count must reflect ACTUAL writes, not submissions. "
+                "If the write throws, the summary's :turn-count / "
+                ":tool-call-count must stay accurate — otherwise the EDN "
+                "summary and the JSONL disagree on how many turns happened.")
+    (let [tmp (fresh-dir)
+          not-a-dir (str tmp "/regular-file-not-a-dir")
+          _ (spit not-a-dir "seed")]
+      (with-training-dir not-a-dir
+        (tl/record-tool-call! "clojure_eval" {} ["ok"] false)
+        (tl/record-tool-call! "clojure_eval" {} ["ok"] false)
+        (drain!)
+        (let [{:keys [turn-count tools-used]} @@#'tl/session-state]
+          (is (zero? turn-count)
+              "no writes landed -> turn-count must be 0")
+          (is (empty? tools-used)
+              "no writes landed -> tools-used stays empty")
+          (is (= 2 @tl/failure-count)
+              "both submissions bumped the failure counter"))))))
+
+(deftest flush-and-summary-drain-writes-accurate-counts-test
+  (testing (str "the shutdown flush must drain in-flight writes BEFORE "
+                "the summary is written. Regression fixture for the "
+                "'summary reports N while JSONL has M<N' class of bug.")
+    (let [dir (fresh-dir)]
+      (with-training-dir dir
+        (dotimes [i 3]
+          (tl/record-tool-call! "clojure_eval"
+                                {:code (str "(inc " i ")")}
+                                [(str (inc i))]
+                                false))
+        ;; Simulate the JVM shutdown hook path.
+        (@#'tl/flush-and-write-summary!)
+        (let [lines (list-turn-lines dir)
+              summary-file (io/file dir
+                                    (str "session-"
+                                         (:session-id @@#'tl/session-state)
+                                         "-summary.edn"))
+              summary (when (.exists summary-file)
+                        (read-string (slurp summary-file)))]
+          (is (= 3 (count lines)) "all 3 writes landed on disk")
+          (is (some? summary))
+          (is (= 3 (:turn-count summary))
+              "summary :turn-count matches the JSONL line count")
+          (is (= 3 (:tool-call-count summary))))))))
 
 (deftest emit-never-throws-on-io-failure-test
   (testing (str "the emit MUST swallow every expected exception. Portable "


### PR DESCRIPTION
## Summary

Adds an **opt-in** JSONL emit hook to clojure-mcp so users building
LLM training-corpus pipelines can capture their tool-call
trajectories without asking downstream users to run a fork.

**Off by default.** Enabled by setting the `CLOJURE_MCP_TRAINING_DIR`
environment variable to a writable directory before starting the
server. Zero effect on existing users — the interceptor no-ops when
the env var is unset.

## How it works

Every tool call already flows through `clojure-mcp.core/create-async-tool`'s
`clj-result-k` continuation. This PR adds ONE line inside that
continuation to call `training-log/record-tool-call!` after the
tool has produced its result but before the response goes back to the
client. Each call appends one line to `session-<uuid>-turns.jsonl`;
a `session-<uuid>-summary.edn` snapshots on JVM shutdown.

Emitted line shape (JSON, one per tool call):

```json
{"session-id":"…uuid…",
 "turn-index":0,
 "model":"unknown",
 "tool-calls":[{"tool":"clojure_eval",
                 "input":{"code":"(+ 1 2)"},
                 "output":"3",
                 "status":"ok",
                 "ms":null}],
 "outcome":"verified",
 "timestamp":"2026-08-02T…Z"}
```

## Design constraints

- **Zero effect on tool behaviour.** Any exception in the emit path
  is WARN-logged and swallowed. A bug in the training-log ns CANNOT
  break a tool response. Test asserts this invariant.
- **No new dependencies.** Uses `clojure.data.json` + `taoensso.timbre`
  (both already transitive on `org.clojure/data.json` and
  `com.taoensso/timbre`).
- **Sensitive by design.** Traces contain file contents, shell
  commands, and eval expressions. README section calls this out and
  suggests treating the training dir as private.

## Non-goals

- No network I/O. This PR writes local files only; any dispatch to a
  server is out of scope.
- No PII scrubbing at emit. A downstream ingest is expected to redact
  before publishing.
- Not a new tool. This is a passive interceptor on the existing tool
  dispatch path.

## Changes

- `src/clojure_mcp/training_log.clj` — new (90 LOC)
- `src/clojure_mcp/core.clj` — +2 lines (require + one-line interceptor)
- `test/clojure_mcp/training_log_test.clj` — new (~100 LOC, hermetic)
- `README.md` — new '## 📊 Optional: Training-log emit' section

## Test plan

- [x] `clojure -M:test -n clojure-mcp.training-log-test` — 5 tests,
      11 assertions, 0 failures (covers happy path, disabled no-op,
      error flag, monotonic turn-index, emit-never-throws invariant)
- [x] `clojure -M:test -n clojure-mcp.core-test` — 6 tests, 17
      assertions, 0 failures (existing tests unchanged)

## Reference

The emitted shape is designed to be consumed by any pipeline that
reads the documented JSONL. The pipeline that motivated this PR is
described in a sibling repo's `docs/PRD-clojure-mcp-corpus.md` — no
hard coupling; any consumer reading this shape works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional per-session training logs for tool calls.
  - When `CLOJURE_MCP_TRAINING_DIR` is configured, the server records JSONL traces and an EDN session summary containing inputs, outputs, statuses, and timestamps.
  - Logging occurs after tool completion and does not affect tool responses if recording fails.

- **Documentation**
  - Documented configuration and session-log behavior.
  - Added a warning that logs may contain sensitive inputs and outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->